### PR TITLE
Enable Format, Warning, and Coverage by Default

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,6 +18,11 @@ jobs:
             -B build \
             -D BUILD_TESTING=ON
 
+      - name: Check formatting
+        run: |
+          cmake --build build --target fix-format
+          git diff --exit-code HEAD
+
       - name: Build project
         run: cmake --build build
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,7 +18,6 @@ if(CMAKE_CURRENT_SOURCE_DIR STREQUAL CMAKE_SOURCE_DIR)
 
   # Import Format.cmake to format source code
   cpmaddpackage("gh:threeal/Format.cmake#auto-install-cmake-format")
-  add_dependencies(errors fix-format)
 
   if(BUILD_TESTING)
     enable_testing()


### PR DESCRIPTION
This pull request activates formatting, warning, and coverage checks by default. This is accomplished by removing the `CHECK_FORMAT`, `CHECK_WARNING`, and `CHECK_COVERAGE` options. Additionally, a check formatting step is added to the `debug` job because the `fix-format` target now requires manual invocation. The pull request closes #55.