### PR TITLE
Bump Catch2 to Version 3.5.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,7 +23,7 @@ if(CMAKE_CURRENT_SOURCE_DIR STREQUAL CMAKE_SOURCE_DIR)
     enable_testing()
 
     # Import Catch2 as the main testing framework
-    cpmaddpackage("gh:catchorg/Catch2@3.4.0")
+    cpmaddpackage("gh:catchorg/Catch2@3.5.0")
     include("${Catch2_SOURCE_DIR}/extras/Catch.cmake")
 
     # Build tests for the main library


### PR DESCRIPTION
This pull request simply bumps [Catch2](https://github.com/catchorg/Catch2) to version [3.5.0](https://github.com/catchorg/Catch2/releases/tag/v3.5.0).