### PR TITLE
Remove `latest` Branch

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,9 +2,8 @@ name: build
 on:
   workflow_dispatch:
   pull_request:
-    branches: ['*', '!*@latest']
   push:
-    branches: ['*@latest', 'main']
+    branches: [main]
 jobs:
   debug:
     runs-on: ubuntu-latest


### PR DESCRIPTION
This pull request removed the `latest` branch by removing that branch from affecting triggers in the CI workflow. It closes #63.