### PR TITLE
Bump CPM.cmake to v0.38.7

### DIFF
--- a/cmake/CPM.cmake
+++ b/cmake/CPM.cmake
@@ -3,7 +3,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2019-2023 Lars Melchior and contributors
 
 set(CPM_DOWNLOAD_VERSION 0.38.7)
-set(CPM_HASH_SUM 83e5eb71b2bbb8b1f2ad38f1950287a057624e385c238f6087f94cdfc44af9c5)
+set(CPM_HASH_SUM 14ea07dfb484cad5db4ee1c75fd6a911)
 
 if(CPM_SOURCE_CACHE)
   set(CPM_DOWNLOAD_LOCATION "${CPM_SOURCE_CACHE}/cpm/CPM_${CPM_DOWNLOAD_VERSION}.cmake")
@@ -17,6 +17,6 @@ endif()
 get_filename_component(CPM_DOWNLOAD_LOCATION ${CPM_DOWNLOAD_LOCATION} ABSOLUTE)
 
 file(DOWNLOAD https://github.com/cpm-cmake/CPM.cmake/releases/download/v${CPM_DOWNLOAD_VERSION}/CPM.cmake
-     ${CPM_DOWNLOAD_LOCATION} EXPECTED_HASH SHA256=${CPM_HASH_SUM})
+     ${CPM_DOWNLOAD_LOCATION} EXPECTED_MD5 ${CPM_HASH_SUM})
 
 include(${CPM_DOWNLOAD_LOCATION})

--- a/cmake/CPM.cmake
+++ b/cmake/CPM.cmake
@@ -2,8 +2,8 @@
 #
 # SPDX-FileCopyrightText: Copyright (c) 2019-2023 Lars Melchior and contributors
 
-set(CPM_DOWNLOAD_VERSION 0.38.6)
-set(CPM_HASH_SUM "11c3fa5f1ba14f15d31c2fb63dbc8628ee133d81c8d764caad9a8db9e0bacb07")
+set(CPM_DOWNLOAD_VERSION 0.38.7)
+set(CPM_HASH_SUM 83e5eb71b2bbb8b1f2ad38f1950287a057624e385c238f6087f94cdfc44af9c5)
 
 if(CPM_SOURCE_CACHE)
   set(CPM_DOWNLOAD_LOCATION "${CPM_SOURCE_CACHE}/cpm/CPM_${CPM_DOWNLOAD_VERSION}.cmake")


### PR DESCRIPTION
This pull request introduces the following changes:
- Bump [CPM.cmake](https://github.com/cpm-cmake/CPM.cmake) to use version [0.38.7](https://github.com/cpm-cmake/CPM.cmake/releases/tag/v0.38.7).
- Use `EXPECTED_MD5` instead to check for downloaded CPM.cmake file hash.