### PR TITLE
Skip CMake Formatting

### DIFF
--- a/.cmake-format
+++ b/.cmake-format
@@ -1,4 +1,0 @@
-{
-    "line_width": 120,
-    "max_subgroups_hwrap": 3
-}

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,5 @@
 .*
 !.clang*
-!.cmake*
 !.git*
 
 build

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,7 +17,11 @@ if(CMAKE_CURRENT_SOURCE_DIR STREQUAL CMAKE_SOURCE_DIR)
   option(BUILD_DOCS "Enable documentations build" OFF)
 
   # Import Format.cmake to format source code
-  cpmaddpackage("gh:threeal/Format.cmake#auto-install-cmake-format")
+  cpmaddpackage(
+    GITHUB_REPOSITORY threeal/Format.cmake
+    GIT_TAG auto-install-cmake-format
+    OPTIONS "FORMAT_SKIP_CMAKE ON"
+  )
 
   if(BUILD_TESTING)
     enable_testing()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,8 +18,8 @@ if(CMAKE_CURRENT_SOURCE_DIR STREQUAL CMAKE_SOURCE_DIR)
 
   # Import Format.cmake to format source code
   cpmaddpackage(
-    GITHUB_REPOSITORY threeal/Format.cmake
-    GIT_TAG auto-install-cmake-format
+    GITHUB_REPOSITORY TheLartians/Format.cmake
+    VERSION 1.8.0
     OPTIONS "FORMAT_SKIP_CMAKE ON"
   )
 


### PR DESCRIPTION
This pull request addresses #66 by introducing the following changes:
- Modifies the Format.cmake dependency by using `TheLartians/Format.cmake@1.8.0` with `FORMAT_SKIP_CMAKE` option enabled.
- Removes unused `.cmake-format` configuration file.