### PR TITLE
Bump CMake Minimum Version to 3.12

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.12)
 
 project(errors)
 


### PR DESCRIPTION
This pull request bumps the CMake minimum required version to `3.12` because this project requires the `cxx_std_20` feature which is only available since CMake version `3.12` as could be seen in [here](https://cmake.org/cmake/help/latest/prop_gbl/CMAKE_CXX_KNOWN_FEATURES.html).