### PR TITLE
Rename Namespace to `errors`

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -8,11 +8,11 @@ A `C++`_ package that provides utilities for error handling.
 API Docs
 --------
 
-.. doxygenfunction:: error::make
+.. doxygenfunction:: errors::make
 
-.. doxygenfunction:: error::format
+.. doxygenfunction:: errors::format
 
-.. doxygenstruct:: error::Error
+.. doxygenstruct:: errors::Error
    :members:
 
 License

--- a/include/errors/error.hpp
+++ b/include/errors/error.hpp
@@ -6,7 +6,7 @@
 #include <string>
 #include <utility>
 
-namespace error {
+namespace errors {
 
 /**
  * @brief Represents error information.
@@ -26,13 +26,13 @@ struct Error {
    * stream.
    *
    * @code{.cpp}
-   * const auto err = error::make("unknown error");
+   * const auto err = errors::make("unknown error");
    *
    * // Print "error: unknown error"
    * std::cout << err << std::endl;
    * @endcode
    */
-  friend std::ostream& operator<<(std::ostream& os, const error::Error& err);
+  friend std::ostream& operator<<(std::ostream& os, const errors::Error& err);
 
   /**
    * @brief Checks if two error objects are equal.
@@ -43,7 +43,7 @@ struct Error {
    * This operator allows the comparison of two error objects using the == operator.
    *
    * @code{.cpp}
-   * const auto err = error::make("unknown error");
+   * const auto err = errors::make("unknown error");
    * const auto other_err = err;
    *
    * assert(err == other_err);
@@ -60,8 +60,8 @@ struct Error {
    * This operator allows the comparison of two error objects using the != operator.
    *
    * @code{.cpp}
-   * const auto err = error::make("unknown error");
-   * const auto other_err = error::make("other error");
+   * const auto err = errors::make("unknown error");
+   * const auto other_err = errors::make("other error");
    *
    * assert(err != other_err);
    * @endcode
@@ -85,14 +85,14 @@ Error make(const std::string& msg);
  */
 template <typename... T>
 Error format(fmt::format_string<T...> fmt, T&&... args) {
-  return error::make(fmt::format(fmt, std::forward<T>(args)...));
+  return errors::make(fmt::format(fmt, std::forward<T>(args)...));
 }
 
 }  // namespace error
 
 template <>
-struct fmt::formatter<error::Error> {
+struct fmt::formatter<errors::Error> {
   format_parse_context::iterator parse(format_parse_context& ctx) const;
-  format_context::iterator format(const error::Error& err,
+  format_context::iterator format(const errors::Error& err,
                                   format_context& ctx) const;
 };

--- a/src/error.cpp
+++ b/src/error.cpp
@@ -1,8 +1,8 @@
 #include <errors/error.hpp>
 
-namespace error {
+namespace errors {
 
-std::ostream& operator<<(std::ostream& os, const error::Error& err) {
+std::ostream& operator<<(std::ostream& os, const errors::Error& err) {
   return os << "error: " << err.message;
 }
 
@@ -20,13 +20,13 @@ Error make(const std::string& msg) { return Error{.message = msg}; }
 
 namespace fmt {
 
-format_parse_context::iterator formatter<error::Error>::parse(
+format_parse_context::iterator formatter<errors::Error>::parse(
     format_parse_context& ctx) const {
   return ctx.begin();
 }
 
-format_context::iterator formatter<error::Error>::format(
-    const error::Error& err, format_context& ctx) const {
+format_context::iterator formatter<errors::Error>::format(
+    const errors::Error& err, format_context& ctx) const {
   return format_to(ctx.out(), "error: {}", err.message);
 }
 

--- a/test/error_test.cpp
+++ b/test/error_test.cpp
@@ -6,27 +6,27 @@
 #include <string>
 
 TEST_CASE("Error Construction") {
-  const error::Error err = error::make("unknown error");
+  const errors::Error err = errors::make("unknown error");
   REQUIRE(err.message == "unknown error");
 }
 
 TEST_CASE("Error Construction With Formatting") {
-  const error::Error err = error::format("HTTP error {}", 404);
+  const errors::Error err = errors::format("HTTP error {}", 404);
   REQUIRE(err.message == "HTTP error 404");
 }
 
 TEST_CASE("Error Comparison") {
-  const auto err = error::make("unknown error");
+  const auto err = errors::make("unknown error");
   const auto err_copy = err;
   CHECK(err == err_copy);
   CHECK_FALSE(err != err_copy);
-  const auto other_err = error::make("other error");
+  const auto other_err = errors::make("other error");
   CHECK_FALSE(err == other_err);
   CHECK(err != other_err);
 }
 
 TEST_CASE("Error Printing") {
-  const auto err = error::make("unknown error");
+  const auto err = errors::make("unknown error");
 
   SECTION("Using ostream") {
     const auto ss = std::stringstream() << err;


### PR DESCRIPTION
This pull request resolves #76 by simply renames the namespace from `error` to `errors`.