### PR TITLE
Store Message as a Shared Constant String

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -12,7 +12,7 @@ API Docs
 
 .. doxygenfunction:: errors::format
 
-.. doxygenstruct:: errors::Error
+.. doxygenclass:: errors::Error
    :members:
 
 License

--- a/include/errors/error.hpp
+++ b/include/errors/error.hpp
@@ -17,6 +17,8 @@ class Error {
   /** The shared pointer of the error message. */
   const std::shared_ptr<const std::string> message_ptr;
 
+  Error(const std::shared_ptr<const std::string>& message_ptr);
+
   /**
    * @brief Returns the error message.
    *

--- a/include/errors/error.hpp
+++ b/include/errors/error.hpp
@@ -13,10 +13,10 @@ namespace errors {
  * @brief Represents error information.
  */
 class Error {
- public:
-  /** The shared pointer of the error message. */
+ private:
   const std::shared_ptr<const std::string> message_ptr;
 
+ public:
   Error(const std::shared_ptr<const std::string>& message_ptr);
 
   /**

--- a/include/errors/error.hpp
+++ b/include/errors/error.hpp
@@ -2,6 +2,7 @@
 
 #include <fmt/core.h>
 
+#include <memory>
 #include <ostream>
 #include <string>
 #include <utility>
@@ -13,7 +14,8 @@ namespace errors {
  */
 class Error {
  public:
-  const std::string message; /**< The error message. */
+  /** The shared pointer of the error message. */
+  const std::shared_ptr<const std::string> message;
 
   /**
    * @brief Writes the string representation of an error object to the given

--- a/include/errors/error.hpp
+++ b/include/errors/error.hpp
@@ -11,7 +11,8 @@ namespace errors {
 /**
  * @brief Represents error information.
  */
-struct Error {
+class Error {
+ public:
   const std::string message; /**< The error message. */
 
   /**

--- a/include/errors/error.hpp
+++ b/include/errors/error.hpp
@@ -15,7 +15,19 @@ namespace errors {
 class Error {
  public:
   /** The shared pointer of the error message. */
-  const std::shared_ptr<const std::string> message;
+  const std::shared_ptr<const std::string> message_ptr;
+
+  /**
+   * @brief Returns the error message.
+   *
+   * @code{.cpp}
+   * const auto err = errors::make("unknown error");
+   *
+   * // Print "unknown error"
+   * std::cout << err << std::endl;
+   * @endcode
+   */
+  std::string message() const;
 
   /**
    * @brief Writes the string representation of an error object to the given

--- a/src/error.cpp
+++ b/src/error.cpp
@@ -2,6 +2,8 @@
 
 namespace errors {
 
+Error::Error(const std::shared_ptr<const std::string>& message_ptr) : message_ptr(message_ptr) {}
+
 std::string Error::message() const {
   if (!message_ptr) return "no error";
   return *message_ptr;
@@ -20,7 +22,7 @@ bool operator!=(const Error& lhs, const Error& rhs) {
 }
 
 Error make(const std::string& msg) {
-  return Error{.message_ptr = std::make_shared<const std::string>(msg)};
+  return Error(std::make_shared<const std::string>(msg));
 }
 
 }  // namespace error

--- a/src/error.cpp
+++ b/src/error.cpp
@@ -2,20 +2,25 @@
 
 namespace errors {
 
+std::string Error::message() const {
+  if (!message_ptr) return "no error";
+  return *message_ptr;
+}
+
 std::ostream& operator<<(std::ostream& os, const errors::Error& err) {
-  return os << "error: " << *err.message;
+  return os << "error: " << err.message();
 }
 
 bool operator==(const Error& lhs, const Error& rhs) {
-  return *lhs.message == *rhs.message;
+  return lhs.message() == rhs.message();
 }
 
 bool operator!=(const Error& lhs, const Error& rhs) {
-  return *lhs.message != *rhs.message;
+  return lhs.message() != rhs.message();
 }
 
 Error make(const std::string& msg) {
-  return Error{.message = std::make_shared<const std::string>(msg)};
+  return Error{.message_ptr = std::make_shared<const std::string>(msg)};
 }
 
 }  // namespace error
@@ -29,7 +34,7 @@ format_parse_context::iterator formatter<errors::Error>::parse(
 
 format_context::iterator formatter<errors::Error>::format(
     const errors::Error& err, format_context& ctx) const {
-  return format_to(ctx.out(), "error: {}", *err.message);
+  return format_to(ctx.out(), "error: {}", err.message());
 }
 
 }  // namespace fmt

--- a/src/error.cpp
+++ b/src/error.cpp
@@ -3,18 +3,20 @@
 namespace errors {
 
 std::ostream& operator<<(std::ostream& os, const errors::Error& err) {
-  return os << "error: " << err.message;
+  return os << "error: " << *err.message;
 }
 
 bool operator==(const Error& lhs, const Error& rhs) {
-  return lhs.message == rhs.message;
+  return *lhs.message == *rhs.message;
 }
 
 bool operator!=(const Error& lhs, const Error& rhs) {
-  return lhs.message != rhs.message;
+  return *lhs.message != *rhs.message;
 }
 
-Error make(const std::string& msg) { return Error{.message = msg}; }
+Error make(const std::string& msg) {
+  return Error{.message = std::make_shared<const std::string>(msg)};
+}
 
 }  // namespace error
 
@@ -27,7 +29,7 @@ format_parse_context::iterator formatter<errors::Error>::parse(
 
 format_context::iterator formatter<errors::Error>::format(
     const errors::Error& err, format_context& ctx) const {
-  return format_to(ctx.out(), "error: {}", err.message);
+  return format_to(ctx.out(), "error: {}", *err.message);
 }
 
 }  // namespace fmt

--- a/test/error_test.cpp
+++ b/test/error_test.cpp
@@ -7,12 +7,12 @@
 
 TEST_CASE("Error Construction") {
   const errors::Error err = errors::make("unknown error");
-  REQUIRE(*err.message == "unknown error");
+  REQUIRE(err.message() == "unknown error");
 }
 
 TEST_CASE("Error Construction With Formatting") {
   const errors::Error err = errors::format("HTTP error {}", 404);
-  REQUIRE(*err.message == "HTTP error 404");
+  REQUIRE(err.message() == "HTTP error 404");
 }
 
 TEST_CASE("Error Comparison") {

--- a/test/error_test.cpp
+++ b/test/error_test.cpp
@@ -7,12 +7,12 @@
 
 TEST_CASE("Error Construction") {
   const errors::Error err = errors::make("unknown error");
-  REQUIRE(err.message == "unknown error");
+  REQUIRE(*err.message == "unknown error");
 }
 
 TEST_CASE("Error Construction With Formatting") {
   const errors::Error err = errors::format("HTTP error {}", 404);
-  REQUIRE(err.message == "HTTP error 404");
+  REQUIRE(*err.message == "HTTP error 404");
 }
 
 TEST_CASE("Error Comparison") {


### PR DESCRIPTION
This pull request resolves #75 by introducing the following changes:
- Modifies the `Error` struct to be a class.
- Modifies the error message to be stored as a `const std::shared_ptr<const std::string>`.
- Adds an `Error::message` method for getting the error message string from the shared pointer.
- Adds an `Error::Error(const std::shared_ptr<const std::string>&)` constructor.