### PR TITLE
Disable Exception Support in Testing

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -48,7 +48,7 @@ if(CMAKE_CURRENT_SOURCE_DIR STREQUAL CMAKE_SOURCE_DIR)
 
     # Enable support to check for test coverage
     if(NOT MSVC)
-      target_compile_options(errors_test PRIVATE --coverage -O0)
+      target_compile_options(errors_test PRIVATE --coverage -O0 -fno-exceptions)
       target_link_options(errors_test PRIVATE --coverage)
     endif()
 


### PR DESCRIPTION
This pull request resolves #83 by appending `-fno-exceptions` option in the `errors_test` target.