### PR TITLE
Remove Equality Operators in `Error` Class

### DIFF
--- a/include/errors/error.hpp
+++ b/include/errors/error.hpp
@@ -50,40 +50,6 @@ class Error {
    * @endcode
    */
   friend std::ostream& operator<<(std::ostream& os, const errors::Error& err);
-
-  /**
-   * @brief Checks if two error objects are equal.
-   * @param lhs The left-hand side error object.
-   * @param rhs The right-hand side error object.
-   * @return True if equal, false otherwise.
-   *
-   * This operator allows the comparison of two error objects using the == operator.
-   *
-   * @code{.cpp}
-   * const auto err = errors::make("unknown error");
-   * const auto other_err = err;
-   *
-   * assert(err == other_err);
-   * @endcode
-   */
-  friend bool operator==(const Error& lhs, const Error& rhs);
-
-  /**
-   * @brief Checks if two error objects are not equal.
-   * @param lhs The left-hand side error object.
-   * @param rhs The right-hand side error object.
-   * @return True if not equal, false otherwise.
-   *
-   * This operator allows the comparison of two error objects using the != operator.
-   *
-   * @code{.cpp}
-   * const auto err = errors::make("unknown error");
-   * const auto other_err = errors::make("other error");
-   *
-   * assert(err != other_err);
-   * @endcode
-   */
-  friend bool operator!=(const Error& lhs, const Error& rhs);
 };
 
 /**

--- a/src/error.cpp
+++ b/src/error.cpp
@@ -13,14 +13,6 @@ std::ostream& operator<<(std::ostream& os, const errors::Error& err) {
   return os << "error: " << err.message();
 }
 
-bool operator==(const Error& lhs, const Error& rhs) {
-  return lhs.message() == rhs.message();
-}
-
-bool operator!=(const Error& lhs, const Error& rhs) {
-  return lhs.message() != rhs.message();
-}
-
 Error make(const std::string& msg) {
   return Error(std::make_shared<const std::string>(msg));
 }

--- a/test/error_test.cpp
+++ b/test/error_test.cpp
@@ -15,16 +15,6 @@ TEST_CASE("Error Construction With Formatting") {
   REQUIRE(err.message() == "HTTP error 404");
 }
 
-TEST_CASE("Error Comparison") {
-  const auto err = errors::make("unknown error");
-  const auto err_copy = err;
-  CHECK(err == err_copy);
-  CHECK_FALSE(err != err_copy);
-  const auto other_err = errors::make("other error");
-  CHECK_FALSE(err == other_err);
-  CHECK(err != other_err);
-}
-
 TEST_CASE("Error Printing") {
   const auto err = errors::make("unknown error");
 


### PR DESCRIPTION
This pull request resolves #81 by removing `operator==` and `operator!=` from the `errors::Error` class.