### PR TITLE
Modify Error Creation Functions to Friend Functions

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -8,8 +8,6 @@ A `C++`_ package that provides utilities for error handling.
 API Docs
 --------
 
-.. doxygenfunction:: errors::format
-
 .. doxygenclass:: errors::Error
    :members:
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -8,8 +8,6 @@ A `C++`_ package that provides utilities for error handling.
 API Docs
 --------
 
-.. doxygenfunction:: errors::make
-
 .. doxygenfunction:: errors::format
 
 .. doxygenclass:: errors::Error

--- a/include/errors/error.hpp
+++ b/include/errors/error.hpp
@@ -33,6 +33,9 @@ class Error {
 
   friend Error make(const std::string& msg);
 
+  template <typename... T>
+  friend Error format(fmt::format_string<T...> fmt, T&&... args);
+
   /**
    * @brief Writes the string representation of an error object to the given
    * output stream.

--- a/include/errors/error.hpp
+++ b/include/errors/error.hpp
@@ -16,9 +16,9 @@ class Error {
  private:
   const std::shared_ptr<const std::string> message_ptr;
 
- public:
   Error(const std::shared_ptr<const std::string>& message_ptr);
 
+ public:
   /**
    * @brief Returns the error message.
    *

--- a/include/errors/error.hpp
+++ b/include/errors/error.hpp
@@ -31,6 +31,8 @@ class Error {
    */
   std::string message() const;
 
+  friend Error make(const std::string& msg);
+
   /**
    * @brief Writes the string representation of an error object to the given
    * output stream.


### PR DESCRIPTION
This pull request resolves #82 by setting the `errors::make` and `errors::format` functions to be friend functionts of the `error::Error` class. It also modifies the `Error::Error` constructor to be private. 