### PR TITLE
Separate Format Components

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,15 +2,12 @@ cmake_minimum_required(VERSION 3.12)
 
 project(errors)
 
-# Import dependencies
+# Initialize CPM.cmake
 include(cmake/CPM.cmake)
-cpmaddpackage("gh:fmtlib/fmt#10.0.0")
 
 # Build the main library
 add_library(errors src/error.cpp)
 target_include_directories(errors PUBLIC include)
-target_link_libraries(errors PUBLIC fmt)
-target_compile_features(errors PRIVATE cxx_std_20)
 
 # Check if this project is the main project
 if(CMAKE_CURRENT_SOURCE_DIR STREQUAL CMAKE_SOURCE_DIR)
@@ -37,14 +34,11 @@ if(CMAKE_CURRENT_SOURCE_DIR STREQUAL CMAKE_SOURCE_DIR)
     # Append the main library properties instead of linking the library.
     get_target_property(errors_SOURCES errors SOURCES)
     get_target_property(errors_INCLUDES errors INCLUDE_DIRECTORIES)
-    get_target_property(errors_LIBRARIES errors LINK_LIBRARIES)
-    get_target_property(errors_FEATURES errors COMPILE_FEATURES)
 
     # Build tests for the main library
     add_executable(errors_test test/error_test.cpp ${errors_SOURCES})
     target_include_directories(errors_test PRIVATE ${errors_INCLUDES})
-    target_link_libraries(errors_test PRIVATE Catch2::Catch2WithMain ${errors_LIBRARIES})
-    target_compile_features(errors_test PRIVATE ${errors_FEATURES})
+    target_link_libraries(errors_test PRIVATE Catch2::Catch2WithMain)
 
     # Enable support to check for test coverage
     if(NOT MSVC)
@@ -61,3 +55,5 @@ if(CMAKE_CURRENT_SOURCE_DIR STREQUAL CMAKE_SOURCE_DIR)
     add_xml_docs(docs include/errors/error.hpp)
   endif()
 endif()
+
+add_subdirectory(components)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -56,7 +56,7 @@ if(NOT_SUBPROJECT)
   # Build XML documentation
   if(BUILD_DOCS)
     include(cmake/add_xml_docs.cmake)
-    add_xml_docs(docs include/errors/error.hpp)
+    add_xml_docs(errors_docs include/errors/error.hpp)
   endif()
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,6 +2,10 @@ cmake_minimum_required(VERSION 3.12)
 
 project(errors)
 
+if(CMAKE_CURRENT_SOURCE_DIR STREQUAL CMAKE_SOURCE_DIR)
+  set(NOT_SUBPROJECT TRUE)
+endif()
+
 # Initialize CPM.cmake
 include(cmake/CPM.cmake)
 
@@ -10,7 +14,7 @@ add_library(errors src/error.cpp)
 target_include_directories(errors PUBLIC include)
 
 # Check if this project is the main project
-if(CMAKE_CURRENT_SOURCE_DIR STREQUAL CMAKE_SOURCE_DIR)
+if(NOT_SUBPROJECT)
   option(BUILD_DOCS "Enable documentations build" OFF)
 
   # Statically analyze code by checking for warnings

--- a/components/CMakeLists.txt
+++ b/components/CMakeLists.txt
@@ -1,0 +1,1 @@
+add_subdirectory(format)

--- a/components/format/CMakeLists.txt
+++ b/components/format/CMakeLists.txt
@@ -5,7 +5,7 @@ target_include_directories(errors_format PUBLIC include)
 target_link_libraries(errors_format PUBLIC errors fmt)
 target_compile_features(errors_format PRIVATE cxx_std_20)
 
-if(BUILD_TESTING)
+if(NOT_SUBPROJECT AND BUILD_TESTING)
   # Append the main library properties instead of linking the library.
   get_target_property(errors_format_SOURCES errors_format SOURCES)
   get_target_property(errors_format_INCLUDES errors_format INCLUDE_DIRECTORIES)

--- a/components/format/CMakeLists.txt
+++ b/components/format/CMakeLists.txt
@@ -5,24 +5,31 @@ target_include_directories(errors_format PUBLIC include)
 target_link_libraries(errors_format PUBLIC errors fmt)
 target_compile_features(errors_format PRIVATE cxx_std_20)
 
-if(NOT_SUBPROJECT AND BUILD_TESTING)
-  # Append the main library properties instead of linking the library.
-  get_target_property(errors_format_SOURCES errors_format SOURCES)
-  get_target_property(errors_format_INCLUDES errors_format INCLUDE_DIRECTORIES)
-  get_target_property(errors_format_LIBRARIES errors_format LINK_LIBRARIES)
-  get_target_property(errors_format_FEATURES errors_format COMPILE_FEATURES)
+if(NOT_SUBPROJECT)
+  if (BUILD_TESTING)
+    # Append the main library properties instead of linking the library.
+    get_target_property(errors_format_SOURCES errors_format SOURCES)
+    get_target_property(errors_format_INCLUDES errors_format INCLUDE_DIRECTORIES)
+    get_target_property(errors_format_LIBRARIES errors_format LINK_LIBRARIES)
+    get_target_property(errors_format_FEATURES errors_format COMPILE_FEATURES)
 
-  # Build tests for the main library
-  add_executable(errors_format_test test/format_test.cpp ${errors_format_SOURCES})
-  target_include_directories(errors_format_test PRIVATE ${errors_format_INCLUDES})
-  target_link_libraries(errors_format_test PRIVATE Catch2::Catch2WithMain ${errors_format_LIBRARIES})
-  target_compile_features(errors_format_test PRIVATE ${errors_format_FEATURES})
+    # Build tests for the main library
+    add_executable(errors_format_test test/format_test.cpp ${errors_format_SOURCES})
+    target_include_directories(errors_format_test PRIVATE ${errors_format_INCLUDES})
+    target_link_libraries(errors_format_test PRIVATE Catch2::Catch2WithMain ${errors_format_LIBRARIES})
+    target_compile_features(errors_format_test PRIVATE ${errors_format_FEATURES})
 
-  # Enable support to check for test coverage
-  if(NOT MSVC)
-    target_compile_options(errors_format_test PRIVATE --coverage -O0 -fno-exceptions)
-    target_link_options(errors_format_test PRIVATE --coverage)
+    # Enable support to check for test coverage
+    if(NOT MSVC)
+      target_compile_options(errors_format_test PRIVATE --coverage -O0 -fno-exceptions)
+      target_link_options(errors_format_test PRIVATE --coverage)
+    endif()
+
+    catch_discover_tests(errors_format_test)
   endif()
 
-  catch_discover_tests(errors_format_test)
+  # Build XML documentation
+  if(BUILD_DOCS)
+    add_xml_docs(errors_format_docs include/errors/format.hpp)
+  endif()
 endif()

--- a/components/format/CMakeLists.txt
+++ b/components/format/CMakeLists.txt
@@ -1,0 +1,28 @@
+cpmaddpackage("gh:fmtlib/fmt#10.0.0")
+
+add_library(errors_format src/format.cpp)
+target_include_directories(errors_format PUBLIC include)
+target_link_libraries(errors_format PUBLIC errors fmt)
+target_compile_features(errors_format PRIVATE cxx_std_20)
+
+if(BUILD_TESTING)
+  # Append the main library properties instead of linking the library.
+  get_target_property(errors_format_SOURCES errors_format SOURCES)
+  get_target_property(errors_format_INCLUDES errors_format INCLUDE_DIRECTORIES)
+  get_target_property(errors_format_LIBRARIES errors_format LINK_LIBRARIES)
+  get_target_property(errors_format_FEATURES errors_format COMPILE_FEATURES)
+
+  # Build tests for the main library
+  add_executable(errors_format_test test/format_test.cpp ${errors_format_SOURCES})
+  target_include_directories(errors_format_test PRIVATE ${errors_format_INCLUDES})
+  target_link_libraries(errors_format_test PRIVATE Catch2::Catch2WithMain ${errors_format_LIBRARIES})
+  target_compile_features(errors_format_test PRIVATE ${errors_format_FEATURES})
+
+  # Enable support to check for test coverage
+  if(NOT MSVC)
+    target_compile_options(errors_format_test PRIVATE --coverage -O0 -fno-exceptions)
+    target_link_options(errors_format_test PRIVATE --coverage)
+  endif()
+
+  catch_discover_tests(errors_format_test)
+endif()

--- a/components/format/include/errors/format.hpp
+++ b/components/format/include/errors/format.hpp
@@ -1,0 +1,27 @@
+#pragma once
+
+#include <errors/error.hpp>
+#include <fmt/core.h>
+
+namespace errors {
+
+/**
+ * @brief Creates a new error object with a formatted message.
+ * @tparam T Variadic template parameter pack for format arguments.
+ * @param fmt A format string for the message.
+ * @param args Format arguments.
+ * @return A new error object.
+ */
+template <typename... T>
+Error format(fmt::format_string<T...> fmt, T&&... args) {
+  return errors::make(fmt::format(fmt, std::forward<T>(args)...));
+}
+
+}  // namespace errors
+
+template <>
+struct fmt::formatter<errors::Error> {
+  format_parse_context::iterator parse(format_parse_context& ctx) const;
+  format_context::iterator format(const errors::Error& err,
+                                  format_context& ctx) const;
+};

--- a/components/format/include/errors/format.hpp
+++ b/components/format/include/errors/format.hpp
@@ -19,9 +19,13 @@ Error format(fmt::format_string<T...> fmt, T&&... args) {
 
 }  // namespace errors
 
+namespace fmt {
+
 template <>
-struct fmt::formatter<errors::Error> {
+struct formatter<errors::Error> {
   format_parse_context::iterator parse(format_parse_context& ctx) const;
   format_context::iterator format(const errors::Error& err,
                                   format_context& ctx) const;
 };
+
+}  // namespace fmt

--- a/components/format/include/errors/format.hpp
+++ b/components/format/include/errors/format.hpp
@@ -13,9 +13,7 @@ namespace errors {
  * @return A new error object.
  */
 template <typename... T>
-Error format(fmt::format_string<T...> fmt, T&&... args) {
-  return errors::make(fmt::format(fmt, std::forward<T>(args)...));
-}
+Error format(fmt::format_string<T...> fmt, T&&... args);
 
 }  // namespace errors
 
@@ -29,3 +27,5 @@ struct formatter<errors::Error> {
 };
 
 }  // namespace fmt
+
+#include "format.ipp"

--- a/components/format/include/errors/format.ipp
+++ b/components/format/include/errors/format.ipp
@@ -1,0 +1,8 @@
+namespace errors {
+
+template <typename... T>
+Error format(fmt::format_string<T...> fmt, T&&... args) {
+  return errors::make(fmt::format(fmt, std::forward<T>(args)...));
+}
+
+}  // namespace errors

--- a/components/format/src/format.cpp
+++ b/components/format/src/format.cpp
@@ -1,0 +1,15 @@
+#include <errors/format.hpp>
+
+namespace fmt {
+
+format_parse_context::iterator formatter<errors::Error>::parse(
+    format_parse_context& ctx) const {
+  return ctx.begin();
+}
+
+format_context::iterator formatter<errors::Error>::format(
+    const errors::Error& err, format_context& ctx) const {
+  return format_to(ctx.out(), "error: {}", err.message());
+}
+
+}  // namespace fmt

--- a/components/format/test/format_test.cpp
+++ b/components/format/test/format_test.cpp
@@ -1,0 +1,14 @@
+#include <fmt/core.h>
+
+#include <catch2/catch_test_macros.hpp>
+#include <errors/format.hpp>
+
+TEST_CASE("Error Construction With Formatting") {
+  const errors::Error err = errors::format("HTTP error {}", 404);
+  REQUIRE(err.message() == "HTTP error 404");
+}
+
+TEST_CASE("Error Printing Using fmtlib") {
+  const auto err = errors::make("unknown error");
+  REQUIRE(fmt::format("{}", err) == "error: unknown error");
+}

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -7,10 +7,12 @@ author = 'Alfi Maulana'
 extensions = ['breathe']
 
 subprocess.call('cmake .. -B ../build -D BUILD_DOCS=ON', shell=True)
-subprocess.call('cmake --build ../build --target docs', shell=True)
+subprocess.call('cmake --build ../build --target errors_docs --target errors_format_docs', shell=True)
 
-breathe_projects = {"errors": "../build/docs"}
-breathe_default_project = "errors"
+breathe_projects = {
+    "errors": "../build/errors_docs",
+    "errors_format": "../build/components/format/errors_format_docs"
+}
 
 html_theme = 'furo'
 html_static_path = ['_static']

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -9,7 +9,14 @@ API Docs
 --------
 
 .. doxygenclass:: errors::Error
+   :project: errors
    :members:
+
+Format Component
+^^^^^^^^^^^^^^^^
+
+.. doxygenfunction:: errors::format
+   :project: errors_format
 
 License
 -------

--- a/include/errors/error.hpp
+++ b/include/errors/error.hpp
@@ -1,7 +1,5 @@
 #pragma once
 
-#include <fmt/core.h>
-
 #include <memory>
 #include <ostream>
 #include <string>
@@ -33,9 +31,6 @@ class Error {
 
   friend Error make(const std::string& msg);
 
-  template <typename... T>
-  friend Error format(fmt::format_string<T...> fmt, T&&... args);
-
   /**
    * @brief Writes the string representation of an error object to the given
    * output stream.
@@ -64,23 +59,4 @@ class Error {
  */
 Error make(const std::string& msg);
 
-/**
- * @brief Creates a new error object with a formatted message.
- * @tparam T Variadic template parameter pack for format arguments.
- * @param fmt A format string for the message.
- * @param args Format arguments.
- * @return A new error object.
- */
-template <typename... T>
-Error format(fmt::format_string<T...> fmt, T&&... args) {
-  return errors::make(fmt::format(fmt, std::forward<T>(args)...));
-}
-
 }  // namespace error
-
-template <>
-struct fmt::formatter<errors::Error> {
-  format_parse_context::iterator parse(format_parse_context& ctx) const;
-  format_context::iterator format(const errors::Error& err,
-                                  format_context& ctx) const;
-};

--- a/src/error.cpp
+++ b/src/error.cpp
@@ -18,17 +18,3 @@ Error make(const std::string& msg) {
 }
 
 }  // namespace error
-
-namespace fmt {
-
-format_parse_context::iterator formatter<errors::Error>::parse(
-    format_parse_context& ctx) const {
-  return ctx.begin();
-}
-
-format_context::iterator formatter<errors::Error>::format(
-    const errors::Error& err, format_context& ctx) const {
-  return format_to(ctx.out(), "error: {}", err.message());
-}
-
-}  // namespace fmt

--- a/test/error_test.cpp
+++ b/test/error_test.cpp
@@ -1,29 +1,14 @@
-#include <fmt/core.h>
-
 #include <catch2/catch_test_macros.hpp>
 #include <errors/error.hpp>
 #include <sstream>
-#include <string>
 
 TEST_CASE("Error Construction") {
   const errors::Error err = errors::make("unknown error");
   REQUIRE(err.message() == "unknown error");
 }
 
-TEST_CASE("Error Construction With Formatting") {
-  const errors::Error err = errors::format("HTTP error {}", 404);
-  REQUIRE(err.message() == "HTTP error 404");
-}
-
-TEST_CASE("Error Printing") {
+TEST_CASE("Error Printing Using OStream") {
   const auto err = errors::make("unknown error");
-
-  SECTION("Using ostream") {
-    const auto ss = std::stringstream() << err;
-    REQUIRE(ss.str() == "error: unknown error");
-  }
-
-  SECTION("Using fmtlib") {
-    REQUIRE(fmt::format("{}", err) == "error: unknown error");
-  }
+  const auto ss = std::stringstream() << err;
+  REQUIRE(ss.str() == "error: unknown error");
 }


### PR DESCRIPTION
This pull request resolves #87 by introducing a `format` component that contains an `errors_format` target. The target itself contains an `errors::format` function and a `fmt::formatter<errors::Error>` implementation which is separated from the `errors` target.

This pull request also introduces a `NOT_SUBPROJECT` variable to allow the `format` component to know if the root project is not a subproject, allows the `format` component to build its test target.