### PR TITLE
Build Documentation in CMake

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -48,15 +48,18 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4.1.1
 
-      - name: Install Dependencies
-        run: |
-          sudo apt-get install -y doxygen
-          pip3 install -r docs/requirements.txt
+      - name: Install Doxygen
+        run: sudo apt-get install -y doxygen
+
+      - name: Configure Project
+        uses: threeal/cmake-action@v1.3.0
+        with:
+          options: BUILD_DOCS=ON
 
       - name: Build Documentation
-        run: sphinx-build -b html docs build/docs -W --keep-going
+        run: cmake --build build --target docs
 
       - name: Upload Documentation
         uses: actions/upload-pages-artifact@v3.0.0
         with:
-          path: build/docs
+          path: build/docs/html

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -23,18 +23,21 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4.1.1
 
-      - name: Install Dependencies
-        run: |
-          sudo apt-get install -y doxygen
-          pip3 install -r docs/requirements.txt
+      - name: Install Doxygen
+        run: sudo apt-get install -y doxygen
+
+      - name: Configure Project
+        uses: threeal/cmake-action@v1.3.0
+        with:
+          options: BUILD_DOCS=ON
 
       - name: Build Documentation
-        run: sphinx-build -b html docs docs/build -W --keep-going
+        run: cmake --build build --target docs
 
       - name: Upload Documentation
         uses: actions/upload-pages-artifact@v3.0.0
         with:
-          path: docs/build
+          path: build/docs/html
 
       - name: Deploy Pages
         id: deploy-pages

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -82,3 +82,7 @@ if(NOT_SUBPROJECT)
 endif()
 
 add_subdirectory(components)
+
+if(NOT_SUBPROJECT AND BUILD_DOCS)
+  add_subdirectory(docs)
+endif()

--- a/docs/CMakeLists.txt
+++ b/docs/CMakeLists.txt
@@ -11,12 +11,17 @@ if(NOT RES EQUAL 0 )
   message(FATAL_ERROR "Failed to install Python dependencies:\n${ERR}")
 endif()
 
+get_target_property(errors_docs_BINARY_DIR errors_docs BINARY_DIR)
+get_target_property(errors_format_docs_BINARY_DIR errors_format_docs BINARY_DIR)
+
 add_custom_command(
   OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/html/index.html
   COMMAND ${Python_EXECUTABLE} -m sphinx -b html ${CMAKE_CURRENT_SOURCE_DIR} ${CMAKE_CURRENT_BINARY_DIR}/html -W --keep-going
   DEPENDS
     ${CMAKE_CURRENT_SOURCE_DIR}/conf.py
     ${CMAKE_CURRENT_SOURCE_DIR}/index.rst
+    ${errors_docs_BINARY_DIR}/errors_docs.stamp
+    ${errors_format_docs_BINARY_DIR}/errors_format_docs.stamp
 )
 
 add_custom_target(docs ALL DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/html/index.html)

--- a/docs/CMakeLists.txt
+++ b/docs/CMakeLists.txt
@@ -1,0 +1,23 @@
+find_package(Python REQUIRED)
+
+message(STATUS "Installing Python dependencies")
+execute_process(
+  COMMAND ${Python_EXECUTABLE} -m pip install -r ${CMAKE_CURRENT_SOURCE_DIR}/requirements.txt
+  RESULT_VARIABLE RES
+  ERROR_VARIABLE ERR
+  OUTPUT_QUIET
+)
+if(NOT RES EQUAL 0 )
+  message(FATAL_ERROR "Failed to install Python dependencies:\n${ERR}")
+endif()
+
+add_custom_command(
+  OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/html/index.html
+  COMMAND ${Python_EXECUTABLE} -m sphinx -b html ${CMAKE_CURRENT_SOURCE_DIR} ${CMAKE_CURRENT_BINARY_DIR}/html -W --keep-going
+  DEPENDS
+    ${CMAKE_CURRENT_SOURCE_DIR}/conf.py
+    ${CMAKE_CURRENT_SOURCE_DIR}/index.rst
+)
+
+add_custom_target(docs ALL DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/html/index.html)
+add_dependencies(docs errors_docs errors_format_docs)


### PR DESCRIPTION
This pull request resolves #89 by adding support to build the documentation from CMake. It also modifies the `build-docs` and the `deploy-pages` jobs to build the documentation using CMake.