### PR TITLE
Auto Remove GCDA Files

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -51,6 +51,15 @@ if(NOT_SUBPROJECT)
     if(NOT MSVC)
       target_compile_options(errors_test PRIVATE --coverage -O0 -fno-exceptions)
       target_link_options(errors_test PRIVATE --coverage)
+
+      get_target_property(errors_test_SOURCES errors_test SOURCES)
+      foreach(SOURCE ${errors_test_SOURCES})
+        set(GCDA ${CMAKE_CURRENT_BINARY_DIR}/CMakeFiles/errors_test.dir/${SOURCE}.gcda)
+        add_custom_command(
+          TARGET errors_test PRE_LINK
+          COMMAND ${CMAKE_COMMAND} -E rm -f ${GCDA}
+        )
+      endforeach()
     endif()
 
     catch_discover_tests(errors_test)

--- a/components/format/CMakeLists.txt
+++ b/components/format/CMakeLists.txt
@@ -20,6 +20,15 @@ if(NOT_SUBPROJECT)
     if(NOT MSVC)
       target_compile_options(errors_format_test PRIVATE --coverage -O0 -fno-exceptions)
       target_link_options(errors_format_test PRIVATE --coverage)
+
+      get_target_property(errors_format_test_SOURCES errors_format_test SOURCES)
+      foreach(SOURCE ${errors_format_test_SOURCES})
+        set(GCDA ${CMAKE_CURRENT_BINARY_DIR}/CMakeFiles/errors_format_test.dir/${SOURCE}.gcda)
+        add_custom_command(
+          TARGET errors_format_test PRE_LINK
+          COMMAND ${CMAKE_COMMAND} -E rm -f ${GCDA}
+        )
+      endforeach()
     endif()
 
     catch_discover_tests(errors_format_test)


### PR DESCRIPTION
This pull request resolves #96  by introducing custom commands which will be run automatically before linking the `errors_test` and `errors_format_test` targets to remove the GCDA files related to those targets.