### PR TITLE
Add Support to Create Empty Error

### DIFF
--- a/include/errors/error.hpp
+++ b/include/errors/error.hpp
@@ -18,6 +18,12 @@ class Error {
   Error(const std::shared_ptr<const std::string>& message_ptr);
 
  public:
+
+  /**
+   * @brief Constructs an empty error object.
+   */
+  Error();
+
   /**
    * @brief Returns the error message.
    *

--- a/src/error.cpp
+++ b/src/error.cpp
@@ -4,6 +4,8 @@ namespace errors {
 
 Error::Error(const std::shared_ptr<const std::string>& message_ptr) : message_ptr(message_ptr) {}
 
+Error::Error() {}
+
 std::string_view Error::message() const {
   if (!message_ptr) return "no error";
   return *message_ptr;

--- a/test/error_test.cpp
+++ b/test/error_test.cpp
@@ -8,6 +8,12 @@ TEST_CASE("Error Construction") {
   REQUIRE(err.message() == "unknown error");
 }
 
+TEST_CASE("Empty Error Construction") {
+  const errors::Error err;
+  REQUIRE_FALSE(err);
+  REQUIRE(err.message() == "no error");
+}
+
 TEST_CASE("Error Printing Using OStream") {
   const auto err = errors::make("unknown error");
   const auto ss = std::stringstream() << err;

--- a/test/error_test.cpp
+++ b/test/error_test.cpp
@@ -3,13 +3,9 @@
 #include <sstream>
 
 TEST_CASE("Error Construction") {
-  const errors::Error err = errors::make("unknown error");
-  REQUIRE(err.message() == "unknown error");
-}
-
-TEST_CASE("Error Checking") {
   const auto err = errors::make("unknown error");
   REQUIRE(err);
+  REQUIRE(err.message() == "unknown error");
 }
 
 TEST_CASE("Error Printing Using OStream") {


### PR DESCRIPTION
This pull request resolves #99 by introducing an `Error::Error()` constructor for declaring an empty error object.