### PR TITLE
Add `errors::nil` Function

### DIFF
--- a/include/errors/error.hpp
+++ b/include/errors/error.hpp
@@ -18,12 +18,6 @@ class Error {
   Error(const std::shared_ptr<const std::string>& message_ptr);
 
  public:
-
-  /**
-   * @brief Constructs an empty error object.
-   */
-  Error();
-
   /**
    * @brief Returns the error message.
    *

--- a/include/errors/error.hpp
+++ b/include/errors/error.hpp
@@ -54,6 +54,7 @@ class Error {
   explicit operator bool() const;
 
   friend Error make(const std::string& msg);
+  friend const Error& nil();
 
   /**
    * @brief Writes the string representation of an error object to the given
@@ -82,5 +83,12 @@ class Error {
  * @return A new error object.
  */
 Error make(const std::string& msg);
+
+
+/**
+ * @brief Gets a constant reference of an empty error.
+ * @return A constant reference of an empty error.
+ */
+const Error& nil();
 
 }  // namespace error

--- a/src/error.cpp
+++ b/src/error.cpp
@@ -4,8 +4,6 @@ namespace errors {
 
 Error::Error(const std::shared_ptr<const std::string>& message_ptr) : message_ptr(message_ptr) {}
 
-Error::Error() {}
-
 std::string_view Error::message() const {
   if (!message_ptr) return "no error";
   return *message_ptr;

--- a/src/error.cpp
+++ b/src/error.cpp
@@ -23,4 +23,9 @@ Error make(const std::string& msg) {
   return Error(std::make_shared<const std::string>(msg));
 }
 
+const Error& nil() {
+  static const Error err(nullptr);
+  return err;
+}
+
 }  // namespace error

--- a/test/error_test.cpp
+++ b/test/error_test.cpp
@@ -9,7 +9,7 @@ TEST_CASE("Error Construction") {
 }
 
 TEST_CASE("Empty Error Construction") {
-  const errors::Error err;
+  const auto err = errors::nil();
   REQUIRE_FALSE(err);
   REQUIRE(err.message() == "no error");
 }


### PR DESCRIPTION
This pull request resolves #102 by introducing an `errors::nil` function for creating an empty error by accessing a static constant reference of an empty error. This change also removes the `Error::Error()` constructor because it is no longer needed.