### PR TITLE
Add Examples

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -39,7 +39,7 @@ jobs:
           options: BUILD_EXAMPLES=ON
 
       - name: Build Examples
-        run: cmake --build build
+        run: cmake --build build --target errors_examples
 
   build-docs:
     name: Build Documentation

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -39,7 +39,7 @@ jobs:
           options: BUILD_EXAMPLES=ON
 
       - name: Build Examples
-        run: cmake --build build --target errors_examples
+        run: cmake --build build --target examples
 
   build-docs:
     name: Build Documentation

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -22,6 +22,25 @@ jobs:
       - name: Build Project
         run: cmake --build build --config Release
 
+  build-examples:
+    name: Build Examples
+    runs-on: ${{ matrix.os }}-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu, windows]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4.1.1
+
+      - name: Configure Project
+        uses: threeal/cmake-action@v1.3.0
+        with:
+          options: BUILD_EXAMPLES=ON
+
+      - name: Build Examples
+        run: cmake --build build
+
   build-docs:
     name: Build Documentation
     runs-on: ubuntu-latest

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -73,8 +73,7 @@ if(NOT_SUBPROJECT)
   endif()
 
   if(BUILD_EXAMPLES)
-    add_executable(errors_example_read_file examples/read_file.cpp)
-    target_link_libraries(errors_example_read_file PRIVATE errors)
+    add_subdirectory(examples)
   endif()
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,6 +19,7 @@ target_include_directories(errors PUBLIC include)
 # Check if this project is the main project
 if(NOT_SUBPROJECT)
   option(BUILD_DOCS "Enable documentations build" OFF)
+  option(BUILD_EXAMPLES "Enable examples build" OFF)
 
   # Statically analyze code by checking for warnings
   cpmaddpackage(gh:threeal/CheckWarning.cmake@2.0.1)
@@ -69,6 +70,11 @@ if(NOT_SUBPROJECT)
   if(BUILD_DOCS)
     include(cmake/add_xml_docs.cmake)
     add_xml_docs(errors_docs include/errors/error.hpp)
+  endif()
+
+  if(BUILD_EXAMPLES)
+    add_executable(errors_example_read_file examples/read_file.cpp)
+    target_link_libraries(errors_example_read_file PRIVATE errors)
   endif()
 endif()
 

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -1,5 +1,5 @@
-add_custom_target(errors_examples)
+add_custom_target(examples)
 
-add_executable(errors_example_read_file read_file.cpp)
-target_link_libraries(errors_example_read_file PRIVATE errors)
-add_dependencies(errors_examples errors_example_read_file)
+add_executable(example_read_file read_file.cpp)
+target_link_libraries(example_read_file PRIVATE errors)
+add_dependencies(examples example_read_file)

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -1,0 +1,2 @@
+add_executable(errors_example_read_file read_file.cpp)
+target_link_libraries(errors_example_read_file PRIVATE errors)

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -1,2 +1,5 @@
+add_custom_target(errors_examples)
+
 add_executable(errors_example_read_file read_file.cpp)
 target_link_libraries(errors_example_read_file PRIVATE errors)
+add_dependencies(errors_examples errors_example_read_file)

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -1,5 +1,9 @@
 add_custom_target(examples)
 
+add_executable(example_print_hex print_hex.cpp)
+target_link_libraries(example_print_hex PRIVATE errors)
+add_dependencies(examples example_print_hex)
+
 add_executable(example_read_file read_file.cpp)
 target_link_libraries(example_read_file PRIVATE errors errors_format)
 add_dependencies(examples example_read_file)

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -1,5 +1,5 @@
 add_custom_target(examples)
 
 add_executable(example_read_file read_file.cpp)
-target_link_libraries(example_read_file PRIVATE errors)
+target_link_libraries(example_read_file PRIVATE errors errors_format)
 add_dependencies(examples example_read_file)

--- a/examples/print_hex.cpp
+++ b/examples/print_hex.cpp
@@ -1,0 +1,27 @@
+#include <errors/error.hpp>
+#include <iostream>
+
+errors::Error print_hex(const char* number_str) {
+  int number = std::atoi(number_str);
+  if (number == 0) {
+    return errors::make("is not a number");
+  }
+
+  std::cout << std::hex << number << std::endl;
+  return errors::nil();
+}
+
+int main(int argc, char **argv) {
+  if (argc < 2) {
+    std::cerr << "usage: " << argv[0] << " <number>" << std::endl;
+    return 1;
+  }
+
+  const auto err = print_hex(argv[1]);
+  if (err) {
+    std::cerr << err << std::endl;
+    return 1;
+  }
+
+  return 0;
+}

--- a/examples/read_file.cpp
+++ b/examples/read_file.cpp
@@ -1,0 +1,32 @@
+#include <errors/error.hpp>
+#include <fstream>
+#include <iostream>
+
+errors::Error read_file(const char* filepath) {
+  std::ifstream file(filepath);
+  if (!file.is_open()) {
+    return errors::make("failed to open file");
+  }
+
+  std::string line;
+  while (std::getline(file, line)) {
+    std::cout << line << std::endl;
+  }
+
+  return errors::nil();
+}
+
+int main(int argc, char **argv) {
+  if (argc < 2) {
+    std::cerr << "Usage: " << argv[0] << " <filepath>" << std::endl;
+    return 1;
+  }
+
+  const auto err = read_file(argv[1]);
+  if (err) {
+    std::cerr << err << std::endl;
+    return 1;
+  }
+
+  return 0;
+}

--- a/examples/read_file.cpp
+++ b/examples/read_file.cpp
@@ -5,7 +5,7 @@
 errors::Error read_file(const char* filepath) {
   std::ifstream file(filepath);
   if (!file.is_open()) {
-    return errors::format("failed to open `{}` ({})", filepath, file.rdstate());
+    return errors::format("failed to open `{}` ({})", filepath, static_cast<int>(file.rdstate()));
   }
 
   std::string line;

--- a/examples/read_file.cpp
+++ b/examples/read_file.cpp
@@ -1,16 +1,16 @@
 #include <errors/error.hpp>
+#include <errors/format.hpp>
 #include <fstream>
-#include <iostream>
 
 errors::Error read_file(const char* filepath) {
   std::ifstream file(filepath);
   if (!file.is_open()) {
-    return errors::make("failed to open file");
+    return errors::format("failed to open `{}` ({})", filepath, file.rdstate());
   }
 
   std::string line;
   while (std::getline(file, line)) {
-    std::cout << line << std::endl;
+    fmt::print("{}\n", line);
   }
 
   return errors::nil();
@@ -18,13 +18,13 @@ errors::Error read_file(const char* filepath) {
 
 int main(int argc, char **argv) {
   if (argc < 2) {
-    std::cerr << "Usage: " << argv[0] << " <filepath>" << std::endl;
+    fmt::print(stderr, "usage: {} <filepath>\n", argv[0]);
     return 1;
   }
 
   const auto err = read_file(argv[1]);
   if (err) {
-    std::cerr << err << std::endl;
+    fmt::print(stderr, "{}\n", err);
     return 1;
   }
 


### PR DESCRIPTION
This pull request resolves #104 by introducing `print_hex` and `read_files` examples that utilizes this library. It also adds a `build-examples` job in the `build.yaml` workflow for checking if the examples could be build correctly.