### PR TITLE
Add `nodiscard` Attribute

### DIFF
--- a/include/errors/error.hpp
+++ b/include/errors/error.hpp
@@ -11,7 +11,7 @@ namespace errors {
 /**
  * @brief Represents error information.
  */
-class Error {
+class [[nodiscard]] Error {
  private:
   const std::shared_ptr<const std::string> message_ptr;
 


### PR DESCRIPTION
This pull request resolves #106 by adding a `nodiscard` attribute to the `errors::Error` class.