### PR TITLE
Store Message as a Shared Constant Char Array

### DIFF
--- a/components/format/include/errors/format.ipp
+++ b/components/format/include/errors/format.ipp
@@ -2,7 +2,7 @@ namespace errors {
 
 template <typename... T>
 Error format(fmt::format_string<T...> fmt, T&&... args) {
-  return errors::make(fmt::format(fmt, std::forward<T>(args)...).c_str());
+  return errors::make(fmt::format(fmt, std::forward<T>(args)...));
 }
 
 }  // namespace errors

--- a/components/format/include/errors/format.ipp
+++ b/components/format/include/errors/format.ipp
@@ -2,7 +2,7 @@ namespace errors {
 
 template <typename... T>
 Error format(fmt::format_string<T...> fmt, T&&... args) {
-  return errors::make(fmt::format(fmt, std::forward<T>(args)...));
+  return errors::make(fmt::format(fmt, std::forward<T>(args)...).c_str());
 }
 
 }  // namespace errors

--- a/include/errors/error.hpp
+++ b/include/errors/error.hpp
@@ -13,9 +13,9 @@ namespace errors {
  */
 class Error {
  private:
-  const std::shared_ptr<const std::string> message_ptr;
+  const std::shared_ptr<const char[]> message_ptr;
 
-  Error(const std::shared_ptr<const std::string>& message_ptr);
+  Error(const std::shared_ptr<const char[]>& message_ptr);
 
  public:
   /**

--- a/include/errors/error.hpp
+++ b/include/errors/error.hpp
@@ -47,7 +47,7 @@ class Error {
    */
   explicit operator bool() const;
 
-  friend Error make(const std::string& msg);
+  friend Error make(const char* msg);
   friend const Error& nil();
 
   /**
@@ -76,7 +76,7 @@ class Error {
  * @param msg The error message.
  * @return A new error object.
  */
-Error make(const std::string& msg);
+Error make(const char* msg);
 
 
 /**

--- a/include/errors/error.hpp
+++ b/include/errors/error.hpp
@@ -13,9 +13,9 @@ namespace errors {
  */
 class Error {
  private:
-  const std::shared_ptr<const char[]> message_ptr;
+  const std::shared_ptr<const char[]> msg_ptr;
 
-  Error(const std::shared_ptr<const char[]>& message_ptr);
+  Error(const std::shared_ptr<const char[]>& msg_ptr);
 
  public:
   /**

--- a/include/errors/error.hpp
+++ b/include/errors/error.hpp
@@ -47,7 +47,7 @@ class Error {
    */
   explicit operator bool() const;
 
-  friend Error make(const char* msg);
+  friend Error make(std::string_view msg);
   friend const Error& nil();
 
   /**
@@ -76,7 +76,7 @@ class Error {
  * @param msg The error message.
  * @return A new error object.
  */
-Error make(const char* msg);
+Error make(std::string_view msg);
 
 
 /**

--- a/src/error.cpp
+++ b/src/error.cpp
@@ -1,4 +1,4 @@
-#include <cstring>
+#include <algorithm>
 #include <errors/error.hpp>
 
 namespace errors {
@@ -18,10 +18,11 @@ std::ostream& operator<<(std::ostream& os, const errors::Error& err) {
   return os << "error: " << err.message();
 }
 
-Error make(const char* msg) {
-  auto msg_copy = new char[std::strlen(msg)];
-  std::strcpy(msg_copy, msg);
-  return Error(std::shared_ptr<const char[]>(msg_copy));
+Error make(std::string_view msg) {
+  auto c_msg = new char[msg.size() + 1];
+  msg.copy(c_msg, msg.size());
+  c_msg[msg.size()] = 0;
+  return Error(std::shared_ptr<const char[]>(c_msg));
 }
 
 const Error& nil() {

--- a/src/error.cpp
+++ b/src/error.cpp
@@ -1,12 +1,13 @@
+#include <cstring>
 #include <errors/error.hpp>
 
 namespace errors {
 
-Error::Error(const std::shared_ptr<const std::string>& message_ptr) : message_ptr(message_ptr) {}
+Error::Error(const std::shared_ptr<const char[]>& message_ptr) : message_ptr(message_ptr) {}
 
 std::string_view Error::message() const {
   if (!message_ptr) return "no error";
-  return *message_ptr;
+  return message_ptr.get();
 }
 
 Error::operator bool() const {
@@ -18,7 +19,9 @@ std::ostream& operator<<(std::ostream& os, const errors::Error& err) {
 }
 
 Error make(const char* msg) {
-  return Error(std::make_shared<const std::string>(msg));
+  auto msg_copy = new char[std::strlen(msg)];
+  std::strcpy(msg_copy, msg);
+  return Error(std::shared_ptr<const char[]>(msg_copy));
 }
 
 const Error& nil() {

--- a/src/error.cpp
+++ b/src/error.cpp
@@ -17,7 +17,7 @@ std::ostream& operator<<(std::ostream& os, const errors::Error& err) {
   return os << "error: " << err.message();
 }
 
-Error make(const std::string& msg) {
+Error make(const char* msg) {
   return Error(std::make_shared<const std::string>(msg));
 }
 

--- a/src/error.cpp
+++ b/src/error.cpp
@@ -3,15 +3,15 @@
 
 namespace errors {
 
-Error::Error(const std::shared_ptr<const char[]>& message_ptr) : message_ptr(message_ptr) {}
+Error::Error(const std::shared_ptr<const char[]>& msg_ptr) : msg_ptr(msg_ptr) {}
 
 std::string_view Error::message() const {
-  if (!message_ptr) return "no error";
-  return message_ptr.get();
+  if (!msg_ptr) return "no error";
+  return msg_ptr.get();
 }
 
 Error::operator bool() const {
-  return (bool)message_ptr;
+  return (bool)msg_ptr;
 }
 
 std::ostream& operator<<(std::ostream& os, const errors::Error& err) {


### PR DESCRIPTION
This pull request resolves #100 by modifying the error message from being stored as `std::shared_ptr<const std::string>` to be stored as `std::shared_ptr<const char[]>`.

It also renames the error message variable to `msg_ptr` and modifies the `msg` parameter in the `errors::make` function to use `std::string_view`.