### PR TITLE
Improve Header File Specification Using File Sets

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,7 +14,12 @@ include(cmake/CPM.cmake)
 
 # Build the main library
 add_library(errors src/error.cpp)
-target_include_directories(errors PUBLIC include)
+target_sources(
+  errors PUBLIC
+  FILE_SET HEADERS
+  BASE_DIRS include
+  FILES include/errors/error.hpp
+)
 
 # Check if this project is the main project
 if(NOT_SUBPROJECT)
@@ -41,11 +46,11 @@ if(NOT_SUBPROJECT)
 
     # Append the main library properties instead of linking the library.
     get_target_property(errors_SOURCES errors SOURCES)
-    get_target_property(errors_INCLUDES errors INCLUDE_DIRECTORIES)
+    get_target_property(errors_HEADER_DIRS errors HEADER_DIRS)
 
     # Build tests for the main library
     add_executable(errors_test test/error_test.cpp ${errors_SOURCES})
-    target_include_directories(errors_test PRIVATE ${errors_INCLUDES})
+    target_include_directories(errors_test PRIVATE ${errors_HEADER_DIRS})
     target_link_libraries(errors_test PRIVATE Catch2::Catch2WithMain)
 
     # Enable support to check for test coverage

--- a/components/format/CMakeLists.txt
+++ b/components/format/CMakeLists.txt
@@ -1,19 +1,24 @@
 cpmaddpackage("gh:fmtlib/fmt#10.0.0")
 
 add_library(errors_format src/format.cpp)
-target_include_directories(errors_format PUBLIC include)
+target_sources(
+  errors_format PUBLIC
+  FILE_SET HEADERS
+  BASE_DIRS include
+  FILES include/errors/format.hpp
+)
 target_link_libraries(errors_format PUBLIC errors fmt)
 
 if(NOT_SUBPROJECT)
   if (BUILD_TESTING)
     # Append the main library properties instead of linking the library.
     get_target_property(errors_format_SOURCES errors_format SOURCES)
-    get_target_property(errors_format_INCLUDES errors_format INCLUDE_DIRECTORIES)
+    get_target_property(errors_format_HEADER_DIRS errors_format HEADER_DIRS)
     get_target_property(errors_format_LIBRARIES errors_format LINK_LIBRARIES)
 
     # Build tests for the main library
     add_executable(errors_format_test test/format_test.cpp ${errors_format_SOURCES})
-    target_include_directories(errors_format_test PRIVATE ${errors_format_INCLUDES})
+    target_include_directories(errors_format_test PRIVATE ${errors_format_HEADER_DIRS})
     target_link_libraries(errors_format_test PRIVATE Catch2::Catch2WithMain ${errors_format_LIBRARIES})
 
     # Enable support to check for test coverage


### PR DESCRIPTION
This pull request resolves #111 by substituting the `target_include_directories` function with the `target_sources(FILE_SET)` function to specify header files of a specific target.