### PR TITLE
Enable Export and Installation of Targets

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -22,6 +22,15 @@ jobs:
       - name: Build Project
         run: cmake --build build --config Release
 
+      - name: Install Project
+        run: cmake --install build --prefix install
+
+      - name: Upload Project
+        uses: actions/upload-artifact@v4.0.0
+        with:
+          name: package-${{ matrix.os }}
+          path: install
+
   build-examples:
     name: Build Examples
     runs-on: ${{ matrix.os }}-latest

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 !.git*
 
 build
+install

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -101,3 +101,8 @@ install(
   NAMESPACE errors::
   DESTINATION lib/cmake/Errors
 )
+
+install(
+  FILES cmake/ErrorsConfig.cmake
+  DESTINATION lib/cmake/Errors
+)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -86,3 +86,18 @@ add_subdirectory(components)
 if(NOT_SUBPROJECT AND BUILD_DOCS)
   add_subdirectory(docs)
 endif()
+
+install(
+  TARGETS errors errors_format
+  EXPORT errors_targets
+  LIBRARY DESTINATION lib
+  RUNTIME DESTINATION bin
+  FILE_SET HEADERS
+)
+
+install(
+  EXPORT errors_targets
+  FILE ErrorsTargets.cmake
+  NAMESPACE errors::
+  DESTINATION lib/cmake/Errors
+)

--- a/cmake/ErrorsConfig.cmake
+++ b/cmake/ErrorsConfig.cmake
@@ -1,0 +1,2 @@
+find_package(FMT REQUIRED)
+include(${CMAKE_CURRENT_LIST_DIR}/ErrorsTargets.cmake)


### PR DESCRIPTION
This pull request resolves #109 by adding support to install both `errors` and `errors_format` targets from this project. It also modifies the `build-project` job in the `build.yaml` workflow by adding an install project and an upload project steps for testing the project installation.