### PR TITLE
Bump fmt to Version 10.2.0

### DIFF
--- a/components/format/CMakeLists.txt
+++ b/components/format/CMakeLists.txt
@@ -1,4 +1,4 @@
-cpmaddpackage("gh:fmtlib/fmt#10.0.0")
+cpmaddpackage("gh:fmtlib/fmt#10.2.0")
 
 add_library(errors_format src/format.cpp)
 target_sources(


### PR DESCRIPTION
This pull request simply bumps fmtlib to version [10.2.0](https://github.com/fmtlib/fmt/releases/tag/10.2.0).