### PR TITLE
Mutable Error Message Pointer

### DIFF
--- a/include/errors/error.hpp
+++ b/include/errors/error.hpp
@@ -17,7 +17,7 @@ namespace errors {
  */
 class [[nodiscard]] Error {
  private:
-  const std::shared_ptr<const char[]> msg_ptr;
+  std::shared_ptr<const char[]> msg_ptr;
 
   Error(const std::shared_ptr<const char[]>& msg_ptr);
 


### PR DESCRIPTION
This pull request fixes #129 by removing the `const` specifier from `Error::msg_ptr` to make that variable mutable, allowing copy assignment to the `Error` class.