### PR TITLE
Fix Wrong CPM.cmake Integration Guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Alternatively, you can also integrate this package using [CPM.cmake](https://git
 cpmaddpackage(gh:threeal/errors-cpp@1.0.0)
 
 add_executable(foo foo.cpp)
-target_link_libraries(foo PRIVATE errors::errors)
+target_link_libraries(foo PRIVATE errors)
 ```
 
 ## Usage

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -49,7 +49,7 @@ Alternatively, you can also integrate this package using `CPM.cmake`_:
    cpmaddpackage(gh:threeal/errors-cpp@1.0.0)
 
    add_executable(foo foo.cpp)
-   target_link_libraries(foo PRIVATE errors::errors)
+   target_link_libraries(foo PRIVATE errors)
 
 .. _CMake: https://cmake.org/
 .. _CPM.cmake: https://github.com/cpm-cmake/CPM.cmake


### PR DESCRIPTION
This pull request fixes an error in the CPM.cmake integration guide, where the library to be linked should be `errors` instead of `errors::errors`.