### PR TITLE
Add `CheckCoverage.cmake` Module File

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -62,19 +62,8 @@ if(NOT_SUBPROJECT)
     target_link_libraries(errors_test PRIVATE Catch2::Catch2WithMain)
 
     # Enable support to check for test coverage
-    if(NOT MSVC)
-      target_compile_options(errors_test PRIVATE --coverage -O0 -fno-exceptions)
-      target_link_options(errors_test PRIVATE --coverage)
-
-      get_target_property(errors_test_SOURCES errors_test SOURCES)
-      foreach(SOURCE ${errors_test_SOURCES})
-        set(GCDA ${CMAKE_CURRENT_BINARY_DIR}/CMakeFiles/errors_test.dir/${SOURCE}.gcda)
-        add_custom_command(
-          TARGET errors_test PRE_LINK
-          COMMAND ${CMAKE_COMMAND} -E rm -f ${GCDA}
-        )
-      endforeach()
-    endif()
+    include(CheckCoverage)
+    target_check_coverage(errors_test)
 
     catch_discover_tests(errors_test)
   endif()

--- a/cmake/CheckCoverage.cmake
+++ b/cmake/CheckCoverage.cmake
@@ -1,0 +1,20 @@
+function(target_check_coverage TARGET)
+  if(MSVC)
+    message(WARNING "Test coverage check is not available on MSVC")
+    return()
+  endif()
+
+  target_compile_options(${TARGET} PRIVATE --coverage -O0 -fno-exceptions)
+  target_link_options(${TARGET} PRIVATE --coverage)
+
+  get_target_property(TARGET_BINARY_DIR ${TARGET} BINARY_DIR)
+  get_target_property(TARGET_SOURCES ${TARGET} SOURCES)
+
+  foreach(SOURCE ${TARGET_SOURCES})
+    set(GCDA ${TARGET_BINARY_DIR}/CMakeFiles/${TARGET}.dir/${SOURCE}.gcda)
+    add_custom_command(
+      TARGET ${TARGET} PRE_LINK
+      COMMAND ${CMAKE_COMMAND} -E rm -f ${GCDA}
+    )
+  endforeach()
+endfunction()

--- a/components/format/CMakeLists.txt
+++ b/components/format/CMakeLists.txt
@@ -21,19 +21,8 @@ if(NOT_SUBPROJECT)
     target_link_libraries(errors_format_test PRIVATE Catch2::Catch2WithMain ${errors_format_LIBRARIES})
 
     # Enable support to check for test coverage
-    if(NOT MSVC)
-      target_compile_options(errors_format_test PRIVATE --coverage -O0 -fno-exceptions)
-      target_link_options(errors_format_test PRIVATE --coverage)
-
-      get_target_property(errors_format_test_SOURCES errors_format_test SOURCES)
-      foreach(SOURCE ${errors_format_test_SOURCES})
-        set(GCDA ${CMAKE_CURRENT_BINARY_DIR}/CMakeFiles/errors_format_test.dir/${SOURCE}.gcda)
-        add_custom_command(
-          TARGET errors_format_test PRE_LINK
-          COMMAND ${CMAKE_COMMAND} -E rm -f ${GCDA}
-        )
-      endforeach()
-    endif()
+    include(CheckCoverage)
+    target_check_coverage(errors_format_test)
 
     catch_discover_tests(errors_format_test)
   endif()


### PR DESCRIPTION
This pull request resolves #144 by introducing the `CheckCoverage.cmake` module file that contains a `target_check_coverage` function for enabling test coverage check on a specific target. This change will simplify the content of the root's `CMakeLists.txt` by moving some CMake lines into a separate module.