### PR TITLE
Reorganize CMakeLists

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,32 +8,26 @@ project(
   LANGUAGES CXX
 )
 
-if(CMAKE_CURRENT_SOURCE_DIR STREQUAL CMAKE_SOURCE_DIR)
-  set(NOT_SUBPROJECT TRUE)
-endif()
-
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake)
 
-# Initialize CPM.cmake
-include(CPM)
+if(CMAKE_CURRENT_SOURCE_DIR STREQUAL CMAKE_SOURCE_DIR)
+  set(NOT_SUBPROJECT TRUE)
 
-# Build the main library
-add_library(errors src/error.cpp)
-target_sources(
-  errors PUBLIC
-  FILE_SET HEADERS
-  BASE_DIRS include
-  FILES include/errors/error.hpp
-)
-
-# Check if this project is the main project
-if(NOT_SUBPROJECT)
   option(BUILD_DOCS "Enable documentations build" OFF)
   option(BUILD_EXAMPLES "Enable examples build" OFF)
 
+  if(BUILD_TESTING)
+    enable_testing()
+  endif()
+endif()
+
+# Initialize CPM.cmake
+include(CPM)
+
+if(NOT_SUBPROJECT)
   # Statically analyze code by checking for warnings
   cpmaddpackage(gh:threeal/CheckWarning.cmake@2.0.1)
   add_check_warning()
@@ -44,10 +38,19 @@ if(NOT_SUBPROJECT)
     VERSION 1.8.0
     OPTIONS "FORMAT_SKIP_CMAKE ON"
   )
+endif()
 
+# Build the main library
+add_library(errors src/error.cpp)
+target_sources(
+  errors PUBLIC
+  FILE_SET HEADERS
+  BASE_DIRS include
+  FILES include/errors/error.hpp
+)
+
+if(NOT_SUBPROJECT)
   if(BUILD_TESTING)
-    enable_testing()
-
     # Import Catch2 as the main testing framework
     cpmaddpackage(gh:catchorg/Catch2@3.5.1)
     include(${Catch2_SOURCE_DIR}/extras/Catch.cmake)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -72,16 +72,16 @@ if(NOT_SUBPROJECT)
     include(GenerateDocs)
     target_generate_xml_docs(errors)
   endif()
-
-  if(BUILD_EXAMPLES)
-    add_subdirectory(examples)
-  endif()
 endif()
 
 add_subdirectory(components)
 
 if(NOT_SUBPROJECT AND BUILD_DOCS)
   add_subdirectory(docs)
+endif()
+
+if(NOT_SUBPROJECT AND BUILD_EXAMPLES)
+  add_subdirectory(examples)
 endif()
 
 install(

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -49,32 +49,30 @@ target_sources(
   FILES include/errors/error.hpp
 )
 
-if(NOT_SUBPROJECT)
-  if(BUILD_TESTING)
-    # Import Catch2 as the main testing framework
-    cpmaddpackage(gh:catchorg/Catch2@3.5.1)
-    include(${Catch2_SOURCE_DIR}/extras/Catch.cmake)
+if(NOT_SUBPROJECT AND BUILD_TESTING)
+  # Import Catch2 as the main testing framework
+  cpmaddpackage(gh:catchorg/Catch2@3.5.1)
+  include(${Catch2_SOURCE_DIR}/extras/Catch.cmake)
 
-    # Append the main library properties instead of linking the library.
-    get_target_property(errors_SOURCES errors SOURCES)
-    get_target_property(errors_HEADER_DIRS errors HEADER_DIRS)
+  # Append the main library properties instead of linking the library.
+  get_target_property(errors_SOURCES errors SOURCES)
+  get_target_property(errors_HEADER_DIRS errors HEADER_DIRS)
 
-    # Build tests for the main library
-    add_executable(errors_test test/error_test.cpp ${errors_SOURCES})
-    target_include_directories(errors_test PRIVATE ${errors_HEADER_DIRS})
-    target_link_libraries(errors_test PRIVATE Catch2::Catch2WithMain)
+  # Build tests for the main library
+  add_executable(errors_test test/error_test.cpp ${errors_SOURCES})
+  target_include_directories(errors_test PRIVATE ${errors_HEADER_DIRS})
+  target_link_libraries(errors_test PRIVATE Catch2::Catch2WithMain)
 
-    # Enable support to check for test coverage
-    include(CheckCoverage)
-    target_check_coverage(errors_test)
+  # Enable support to check for test coverage
+  include(CheckCoverage)
+  target_check_coverage(errors_test)
 
-    catch_discover_tests(errors_test)
-  endif()
+  catch_discover_tests(errors_test)
+endif()
 
-  if(BUILD_DOCS)
-    include(GenerateDocs)
-    target_generate_xml_docs(errors)
-  endif()
+if(NOT_SUBPROJECT AND BUILD_DOCS)
+  include(GenerateDocs)
+  target_generate_xml_docs(errors)
 endif()
 
 add_subdirectory(components)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,7 +14,7 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake)
 
 if(CMAKE_CURRENT_SOURCE_DIR STREQUAL CMAKE_SOURCE_DIR)
-  set(NOT_SUBPROJECT TRUE)
+  set(SUBPROJECT OFF)
 
   option(BUILD_DOCS "Enable documentations build" OFF)
   option(BUILD_EXAMPLES "Enable examples build" OFF)
@@ -27,7 +27,7 @@ endif()
 # Initialize CPM.cmake
 include(CPM)
 
-if(NOT_SUBPROJECT)
+if(NOT SUBPROJECT)
   # Statically analyze code by checking for warnings
   cpmaddpackage(gh:threeal/CheckWarning.cmake@2.0.1)
   add_check_warning()
@@ -49,7 +49,7 @@ target_sources(
   FILES include/errors/error.hpp
 )
 
-if(NOT_SUBPROJECT AND BUILD_TESTING)
+if(NOT SUBPROJECT AND BUILD_TESTING)
   # Import Catch2 as the main testing framework
   cpmaddpackage(gh:catchorg/Catch2@3.5.1)
   include(${Catch2_SOURCE_DIR}/extras/Catch.cmake)
@@ -70,18 +70,18 @@ if(NOT_SUBPROJECT AND BUILD_TESTING)
   catch_discover_tests(errors_test)
 endif()
 
-if(NOT_SUBPROJECT AND BUILD_DOCS)
+if(NOT SUBPROJECT AND BUILD_DOCS)
   include(GenerateDocs)
   target_generate_xml_docs(errors)
 endif()
 
 add_subdirectory(components)
 
-if(NOT_SUBPROJECT AND BUILD_DOCS)
+if(NOT SUBPROJECT AND BUILD_DOCS)
   add_subdirectory(docs)
 endif()
 
-if(NOT_SUBPROJECT AND BUILD_EXAMPLES)
+if(NOT SUBPROJECT AND BUILD_EXAMPLES)
   add_subdirectory(examples)
 endif()
 

--- a/components/format/CMakeLists.txt
+++ b/components/format/CMakeLists.txt
@@ -9,7 +9,7 @@ target_sources(
 )
 target_link_libraries(errors_format INTERFACE errors fmt)
 
-if(NOT_SUBPROJECT AND BUILD_TESTING)
+if(NOT SUBPROJECT AND BUILD_TESTING)
   # Append the main library properties instead of linking the library.
   get_target_property(errors_format_HEADER_DIRS errors_format HEADER_DIRS)
   get_target_property(errors_format_LIBRARIES errors_format INTERFACE_LINK_LIBRARIES)
@@ -26,6 +26,6 @@ if(NOT_SUBPROJECT AND BUILD_TESTING)
   catch_discover_tests(errors_format_test)
 endif()
 
-if(NOT_SUBPROJECT AND BUILD_DOCS)
+if(NOT SUBPROJECT AND BUILD_DOCS)
   target_generate_xml_docs(errors_format)
 endif()

--- a/components/format/CMakeLists.txt
+++ b/components/format/CMakeLists.txt
@@ -9,25 +9,23 @@ target_sources(
 )
 target_link_libraries(errors_format INTERFACE errors fmt)
 
-if(NOT_SUBPROJECT)
-  if (BUILD_TESTING)
-    # Append the main library properties instead of linking the library.
-    get_target_property(errors_format_HEADER_DIRS errors_format HEADER_DIRS)
-    get_target_property(errors_format_LIBRARIES errors_format INTERFACE_LINK_LIBRARIES)
+if(NOT_SUBPROJECT AND BUILD_TESTING)
+  # Append the main library properties instead of linking the library.
+  get_target_property(errors_format_HEADER_DIRS errors_format HEADER_DIRS)
+  get_target_property(errors_format_LIBRARIES errors_format INTERFACE_LINK_LIBRARIES)
 
-    # Build tests for the main library
-    add_executable(errors_format_test test/format_test.cpp)
-    target_include_directories(errors_format_test PRIVATE ${errors_format_HEADER_DIRS})
-    target_link_libraries(errors_format_test PRIVATE Catch2::Catch2WithMain ${errors_format_LIBRARIES})
+  # Build tests for the main library
+  add_executable(errors_format_test test/format_test.cpp)
+  target_include_directories(errors_format_test PRIVATE ${errors_format_HEADER_DIRS})
+  target_link_libraries(errors_format_test PRIVATE Catch2::Catch2WithMain ${errors_format_LIBRARIES})
 
-    # Enable support to check for test coverage
-    include(CheckCoverage)
-    target_check_coverage(errors_format_test)
+  # Enable support to check for test coverage
+  include(CheckCoverage)
+  target_check_coverage(errors_format_test)
 
-    catch_discover_tests(errors_format_test)
-  endif()
+  catch_discover_tests(errors_format_test)
+endif()
 
-  if(BUILD_DOCS)
-    target_generate_xml_docs(errors_format)
-  endif()
+if(NOT_SUBPROJECT AND BUILD_DOCS)
+  target_generate_xml_docs(errors_format)
 endif()


### PR DESCRIPTION
This pull request resolves #146 by reorganizing `CMakeLists.txt` files as follows:
- Put build examples declaration after the main build docs declaration.
- Put other global declaration on top of the root's `CMakeLists.txt` file.
- Separate the declaration of each component's build testing and build docs.
- Modify the `NOT_SUBPROJECT` variable to be `SUBPROJECT`.