### PR TITLE
Fix CMake `SUBPROJECT` Variable Check

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,14 +14,14 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake)
 
 if(CMAKE_CURRENT_SOURCE_DIR STREQUAL CMAKE_SOURCE_DIR)
-  set(SUBPROJECT OFF)
-
   option(BUILD_DOCS "Enable documentations build" OFF)
   option(BUILD_EXAMPLES "Enable examples build" OFF)
 
   if(BUILD_TESTING)
     enable_testing()
   endif()
+else()
+  set(SUBPROJECT ON)
 endif()
 
 # Initialize CPM.cmake


### PR DESCRIPTION
This pull request fixes the logic in the `CMakeLists.txt` caused by the `SUBPROJECT` variable being set to `OFF` instead of `ON`. The default value of an undefined variable is off, so basically, using the previous logic means that the `SUBPROJECT` value will always be off. This pull request updates the logic so that the `SUBPROJECT` variable is set to `ON` with the default being `OFF`.