### PR TITLE
Remove Badges from Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,5 @@
 # Errors C++
 
-[![version](https://img.shields.io/github/v/release/threeal/errors-cpp?style=flat-square)](https://github.com/threeal/errors-cpp/releases)
-[![license](https://img.shields.io/github/license/threeal/errors-cpp?style=flat-square)](./LICENSE)
-[![build status](https://img.shields.io/github/actions/workflow/status/threeal/errors-cpp/build.yaml?branch=main&style=flat-square)](https://github.com/threeal/errors-cpp/actions/workflows/build.yaml)
-[![test status](https://img.shields.io/github/actions/workflow/status/threeal/errors-cpp/test.yaml?branch=main&&label=test&style=flat-square)](https://github.com/threeal/errors-cpp/actions/workflows/test.yaml)
-[![deploy status](https://img.shields.io/github/actions/workflow/status/threeal/errors-cpp/deploy.yaml?branch=main&label=deploy&style=flat-square)](https://github.com/threeal/errors-cpp/actions/workflows/deploy.yaml)
-
 Errors C++ is a [C++](https://isocpp.org/) package that provides utilities for error handling.
 This package mainly consists of the `errors::Error` class, representing an object that may contain an error.
 


### PR DESCRIPTION
This pull request resolves #166 by simply removing badges from the `README.md` file.