### PR TITLE
Bump CPM.cmake to Version 0.39.0

### DIFF
--- a/cmake/CPM.cmake
+++ b/cmake/CPM.cmake
@@ -1,7 +1,7 @@
 file(
   DOWNLOAD
-  https://github.com/cpm-cmake/CPM.cmake/releases/download/v0.38.7/CPM.cmake
+  https://github.com/cpm-cmake/CPM.cmake/releases/download/v0.39.0/CPM.cmake
   ${CMAKE_BINARY_DIR}/_deps/CPM.cmake
-  EXPECTED_MD5 14ea07dfb484cad5db4ee1c75fd6a911
+  EXPECTED_MD5 04eefa38baf672f7e8fcd09075122517
 )
 include(${CMAKE_BINARY_DIR}/_deps/CPM.cmake)


### PR DESCRIPTION
This pull request simply bumps the CPM.cmake to version [0.39.0](https://github.com/cpm-cmake/CPM.cmake/releases/tag/v0.39.0).