### PR TITLE
Bump Catch2 to Version 3.5.4

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -52,7 +52,7 @@ target_sources(
 
 if(NOT SUBPROJECT AND BUILD_TESTING)
   # Import Catch2 as the main testing framework
-  cpmaddpackage(gh:catchorg/Catch2@3.5.3)
+  cpmaddpackage(gh:catchorg/Catch2@3.5.4)
   include(${Catch2_SOURCE_DIR}/extras/Catch.cmake)
 
   # Append the main library properties instead of linking the library.


### PR DESCRIPTION
This pull request simply bumps Catch2 to version [3.5.4](https://github.com/catchorg/Catch2/releases/tag/v3.5.4).