### PR TITLE
Utilize FixFormat.cmake

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -19,7 +19,7 @@ jobs:
 
       - name: Check Format
         run: |
-          cmake --build build --target format
+          cmake --build build --target format-all
           git diff --exit-code HEAD
 
   test-project:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,13 +32,6 @@ if(NOT SUBPROJECT)
   cpmaddpackage(gh:threeal/CheckWarning.cmake@2.1.0)
   include(${CheckWarning_SOURCE_DIR}/cmake/CheckWarning.cmake)
   add_check_warning()
-
-  # Import Format.cmake to format source code
-  cpmaddpackage(
-    GITHUB_REPOSITORY TheLartians/Format.cmake
-    VERSION 1.8.0
-    OPTIONS "FORMAT_SKIP_CMAKE ON"
-  )
 endif()
 
 # Build the main library
@@ -84,6 +77,13 @@ endif()
 
 if(NOT SUBPROJECT AND BUILD_EXAMPLES)
   add_subdirectory(examples)
+endif()
+
+if(NOT SUBPROJECT AND BUILD_TESTING)
+  # Enable automatic target formatting.
+  cpmaddpackage(gh:threeal/FixFormat.cmake@1.1.1)
+  include(${FixFormat_SOURCE_DIR}/cmake/FixFormat.cmake)
+  add_fix_format()
 endif()
 
 install(

--- a/include/errors/error.hpp
+++ b/include/errors/error.hpp
@@ -137,4 +137,4 @@ Error make(std::string_view msg);
  */
 const Error& nil();
 
-}  // namespace error
+}  // namespace errors

--- a/src/error.cpp
+++ b/src/error.cpp
@@ -29,4 +29,4 @@ const Error& nil() {
   return err;
 }
 
-}  // namespace error
+}  // namespace errors


### PR DESCRIPTION
This pull request resolves #179 by utilizing the [FixFormat.cmake](https://github.com/threeal/FixFormat.cmake) module for formatting source code within this project, replacing the previously used Format.cmake module.