### PR TITLE
Bump FMT to Version 11.0.0

### DIFF
--- a/components/format/CMakeLists.txt
+++ b/components/format/CMakeLists.txt
@@ -1,4 +1,4 @@
-cpmaddpackage("gh:fmtlib/fmt#10.2.1")
+cpmaddpackage("gh:fmtlib/fmt#11.0.0")
 
 add_library(errors_format INTERFACE)
 target_sources(


### PR DESCRIPTION
This pull request updates the FMT library to version [11.0.0](https://github.com/fmtlib/fmt/releases/tag/11.0.0).