### PR TITLE
Add Option to Enable Test Targets

### DIFF
--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -15,7 +15,7 @@ jobs:
       - name: Configure Project
         uses: threeal/cmake-action@v1.3.0
         with:
-          options: BUILD_TESTING=ON
+          options: ERRORS_ENABLE_TESTS=ON
 
       - name: Check Format
         run: |

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -19,7 +19,7 @@ jobs:
       - name: Configure Project
         uses: threeal/cmake-action@v1.3.0
         with:
-          options: BUILD_TESTING=ON
+          options: ERRORS_ENABLE_TESTS=ON
 
       - name: Build Project
         run: cmake --build build

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,11 +13,13 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake)
 
+option(ERRORS_ENABLE_TESTS "Enable test targets.")
+
 if(PROJECT_IS_TOP_LEVEL)
   option(BUILD_DOCS "Enable documentations build" OFF)
   option(BUILD_EXAMPLES "Enable examples build" OFF)
 
-  if(BUILD_TESTING)
+  if(ERRORS_ENABLE_TESTS)
     enable_testing()
   endif()
 endif()
@@ -41,7 +43,7 @@ target_sources(
   FILES include/errors/error.hpp
 )
 
-if(PROJECT_IS_TOP_LEVEL AND BUILD_TESTING)
+if(PROJECT_IS_TOP_LEVEL AND ERRORS_ENABLE_TESTS)
   # Import Catch2 as the main testing framework
   cpmaddpackage(gh:catchorg/Catch2@3.6.0)
   include(${Catch2_SOURCE_DIR}/extras/Catch.cmake)
@@ -77,7 +79,7 @@ if(PROJECT_IS_TOP_LEVEL AND BUILD_EXAMPLES)
   add_subdirectory(examples)
 endif()
 
-if(PROJECT_IS_TOP_LEVEL AND BUILD_TESTING)
+if(PROJECT_IS_TOP_LEVEL AND ERRORS_ENABLE_TESTS)
   # Enable automatic target formatting.
   cpmaddpackage(gh:threeal/FixFormat.cmake@1.1.1)
   include(${FixFormat_SOURCE_DIR}/cmake/FixFormat.cmake)

--- a/components/format/CMakeLists.txt
+++ b/components/format/CMakeLists.txt
@@ -9,7 +9,7 @@ target_sources(
 )
 target_link_libraries(errors_format INTERFACE errors fmt)
 
-if(PROJECT_IS_TOP_LEVEL AND BUILD_TESTING)
+if(PROJECT_IS_TOP_LEVEL AND ERRORS_ENABLE_TESTS)
   # Append the main library properties instead of linking the library.
   get_target_property(errors_format_HEADER_DIRS errors_format HEADER_DIRS)
   get_target_property(errors_format_LIBRARIES errors_format INTERFACE_LINK_LIBRARIES)


### PR DESCRIPTION
This pull request resolves #191 by adding a `ERRORS_ENABLE_TESTS` option to enable test targets in the project, replacing the `BUILD_TESTING` variable.