### PR TITLE
Bump Catch2 to Version 3.7.1

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -45,7 +45,7 @@ target_sources(
 
 if(PROJECT_IS_TOP_LEVEL AND ERRORS_ENABLE_TESTS)
   # Import Catch2 as the main testing framework
-  cpmaddpackage(gh:catchorg/Catch2@3.7.0)
+  cpmaddpackage(gh:catchorg/Catch2@3.7.1)
   include(${Catch2_SOURCE_DIR}/extras/Catch.cmake)
 
   # Append the main library properties instead of linking the library.


### PR DESCRIPTION
This pull request simply bumps Catch2 to version [3.7.1](https://github.com/catchorg/Catch2/releases/tag/v3.7.1).