### PR TITLE
Fix `format.ipp` File Not Installed

### DIFF
--- a/components/format/CMakeLists.txt
+++ b/components/format/CMakeLists.txt
@@ -6,6 +6,7 @@ target_sources(
   FILE_SET HEADERS
   BASE_DIRS include
   FILES include/errors/format.hpp
+    include/errors/format.ipp
 )
 target_link_libraries(errors_format INTERFACE errors fmt)
 


### PR DESCRIPTION
This pull request resolves #206 by including the `format.ipp` file in the header file set, fixing the issue of it not being included in the project build installation.