### PR TITLE
Add Find Package Modules

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -86,8 +86,8 @@ endif()
 
 if(PROJECT_IS_TOP_LEVEL AND ERRORS_ENABLE_TESTS)
   # Enable automatic target formatting.
-  cpmaddpackage(gh:threeal/FixFormat.cmake@1.1.1)
-  include(${FixFormat_SOURCE_DIR}/cmake/FixFormat.cmake)
+  find_package(FixFormat 1.1.1 REQUIRED)
+  include(FixFormat)
   add_fix_format()
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,6 +24,11 @@ if(PROJECT_IS_TOP_LEVEL)
   endif()
 endif()
 
+# Prefer system packages over the find modules provided by this project.
+if(NOT DEFINED CMAKE_FIND_PACKAGE_PREFER_CONFIG)
+  set(CMAKE_FIND_PACKAGE_PREFER_CONFIG TRUE)
+endif()
+
 # Initialize CPM.cmake
 include(CPM)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,8 +34,8 @@ include(CPM)
 
 if(PROJECT_IS_TOP_LEVEL)
   # Statically analyze code by checking for warnings
-  cpmaddpackage(gh:threeal/CheckWarning.cmake@2.1.0)
-  include(${CheckWarning_SOURCE_DIR}/cmake/CheckWarning.cmake)
+  find_package(CheckWarning 2.1.0 REQUIRED)
+  include(CheckWarning)
   add_check_warning()
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -45,8 +45,8 @@ target_sources(
 
 if(PROJECT_IS_TOP_LEVEL AND ERRORS_ENABLE_TESTS)
   # Import Catch2 as the main testing framework
-  cpmaddpackage(gh:catchorg/Catch2@3.7.1)
-  include(${Catch2_SOURCE_DIR}/extras/Catch.cmake)
+  find_package(Catch2 3.7.1 REQUIRED)
+  include(Catch)
 
   # Append the main library properties instead of linking the library.
   get_target_property(errors_SOURCES errors SOURCES)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,9 +29,6 @@ if(NOT DEFINED CMAKE_FIND_PACKAGE_PREFER_CONFIG)
   set(CMAKE_FIND_PACKAGE_PREFER_CONFIG TRUE)
 endif()
 
-# Initialize CPM.cmake
-include(CPM)
-
 if(PROJECT_IS_TOP_LEVEL)
   # Statically analyze code by checking for warnings
   find_package(CheckWarning 2.1.0 REQUIRED)

--- a/cmake/FindCatch2.cmake
+++ b/cmake/FindCatch2.cmake
@@ -1,3 +1,4 @@
+include(CPM)
 cpmaddpackage(gh:catchorg/Catch2@${Catch2_FIND_VERSION})
 
 include(FindPackageHandleStandardArgs)

--- a/cmake/FindCatch2.cmake
+++ b/cmake/FindCatch2.cmake
@@ -1,0 +1,6 @@
+cpmaddpackage(gh:catchorg/Catch2@${Catch2_FIND_VERSION})
+
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(Catch2 REQUIRED_VARS Catch2_ADDED)
+
+list(PREPEND CMAKE_MODULE_PATH ${Catch2_SOURCE_DIR}/extras)

--- a/cmake/FindCheckWarning.cmake
+++ b/cmake/FindCheckWarning.cmake
@@ -1,0 +1,6 @@
+cpmaddpackage(gh:threeal/CheckWarning.cmake@${CheckWarning_FIND_VERSION})
+
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(CheckWarning REQUIRED_VARS CheckWarning.cmake_ADDED)
+
+list(PREPEND CMAKE_MODULE_PATH ${CheckWarning_SOURCE_DIR}/cmake)

--- a/cmake/FindCheckWarning.cmake
+++ b/cmake/FindCheckWarning.cmake
@@ -1,3 +1,4 @@
+include(CPM)
 cpmaddpackage(gh:threeal/CheckWarning.cmake@${CheckWarning_FIND_VERSION})
 
 include(FindPackageHandleStandardArgs)

--- a/cmake/FindFMT.cmake
+++ b/cmake/FindFMT.cmake
@@ -1,3 +1,4 @@
+include(CPM)
 cpmaddpackage("gh:fmtlib/fmt#${FMT_FIND_VERSION}")
 
 include(FindPackageHandleStandardArgs)

--- a/cmake/FindFMT.cmake
+++ b/cmake/FindFMT.cmake
@@ -1,0 +1,4 @@
+cpmaddpackage("gh:fmtlib/fmt#${FMT_FIND_VERSION}")
+
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(FMT REQUIRED_VARS fmt_ADDED)

--- a/cmake/FindFixFormat.cmake
+++ b/cmake/FindFixFormat.cmake
@@ -1,3 +1,4 @@
+include(CPM)
 cpmaddpackage(gh:threeal/FixFormat.cmake@${FixFormat_FIND_VERSION})
 
 include(FindPackageHandleStandardArgs)

--- a/cmake/FindFixFormat.cmake
+++ b/cmake/FindFixFormat.cmake
@@ -1,0 +1,6 @@
+cpmaddpackage(gh:threeal/FixFormat.cmake@${FixFormat_FIND_VERSION})
+
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(FixFormat REQUIRED_VARS FixFormat.cmake_ADDED)
+
+list(PREPEND CMAKE_MODULE_PATH ${FixFormat_SOURCE_DIR}/cmake)

--- a/components/format/CMakeLists.txt
+++ b/components/format/CMakeLists.txt
@@ -1,4 +1,4 @@
-cpmaddpackage("gh:fmtlib/fmt#11.0.2")
+find_package(FMT 11.0.2 REQUIRED)
 
 add_library(errors_format INTERFACE)
 target_sources(


### PR DESCRIPTION
This pull request resolves #210 by adding find package modules for each dependency of this project. It also sets the [`CMAKE_FIND_PACKAGE_PREFER_CONFIG`](https://cmake.org/cmake/help/latest/variable/CMAKE_FIND_PACKAGE_PREFER_CONFIG.html) variable to true by default, causing this project to search for packages in the system or parent project before using the find modules provided by this project.