### PR TITLE
Bump CheckWarning.cmake to Version 3.0.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,9 +31,8 @@ endif()
 
 if(PROJECT_IS_TOP_LEVEL)
   # Statically analyze code by checking for warnings
-  find_package(CheckWarning 2.1.0 REQUIRED)
-  include(CheckWarning)
-  add_check_warning()
+  find_package(CheckWarning 3.0.0 REQUIRED)
+  add_check_warning(TREAT_WARNINGS_AS_ERRORS)
 endif()
 
 # Build the main library

--- a/cmake/FindCheckWarning.cmake
+++ b/cmake/FindCheckWarning.cmake
@@ -3,5 +3,3 @@ cpmaddpackage(gh:threeal/CheckWarning.cmake@${CheckWarning_FIND_VERSION})
 
 include(FindPackageHandleStandardArgs)
 find_package_handle_standard_args(CheckWarning REQUIRED_VARS CheckWarning.cmake_ADDED)
-
-list(PREPEND CMAKE_MODULE_PATH ${CheckWarning_SOURCE_DIR}/cmake)


### PR DESCRIPTION
This pull request updates the [CheckWarning.cmake](https://github.com/threeal/CheckWarning.cmake) project used by this project to version [3.0.0](https://github.com/threeal/CheckWarning.cmake/releases/tag/v3.0.0).