### PR TITLE
Bump CheckWarning.cmake to Version 3.2.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,7 +31,7 @@ endif()
 
 if(PROJECT_IS_TOP_LEVEL)
   # Statically analyze code by checking for warnings
-  find_package(CheckWarning 3.1.0 REQUIRED)
+  find_package(CheckWarning 3.2.0 REQUIRED)
   add_check_warning(TREAT_WARNINGS_AS_ERRORS)
 endif()
 


### PR DESCRIPTION
This pull request updates the [CheckWarning.cmake](https://github.com/threeal/CheckWarning.cmake) project used by this project to version [3.2.0](https://github.com/threeal/CheckWarning.cmake/releases/tag/v3.2.0).