### PR TITLE
Bump CPM.cmake to Version 0.40.5

### DIFF
--- a/cmake/CPM.cmake
+++ b/cmake/CPM.cmake
@@ -1,7 +1,7 @@
 file(
   DOWNLOAD
-  https://github.com/cpm-cmake/CPM.cmake/releases/download/v0.40.2/CPM.cmake
+  https://github.com/cpm-cmake/CPM.cmake/releases/download/v0.40.5/CPM.cmake
   ${CMAKE_BINARY_DIR}/_deps/CPM.cmake
-  EXPECTED_MD5 4d51aa9dab6104fad39c5b7a692d5e1c
+  EXPECTED_MD5 19cbb284c7b175d239670d47dd9d0e9e
 )
 include(${CMAKE_BINARY_DIR}/_deps/CPM.cmake)


### PR DESCRIPTION
This pull request simply bumps the CPM.cmake to version [0.40.5](https://github.com/cpm-cmake/CPM.cmake/releases/tag/v0.40.5).