### PR TITLE
Bump CPM.cmake to Version 0.40.8

### DIFF
--- a/cmake/CPM.cmake
+++ b/cmake/CPM.cmake
@@ -1,7 +1,7 @@
 file(
   DOWNLOAD
-  https://github.com/cpm-cmake/CPM.cmake/releases/download/v0.40.5/CPM.cmake
+  https://github.com/cpm-cmake/CPM.cmake/releases/download/v0.40.8/CPM.cmake
   ${CMAKE_BINARY_DIR}/_deps/CPM.cmake
-  EXPECTED_MD5 19cbb284c7b175d239670d47dd9d0e9e
+  EXPECTED_MD5 f2c95720301a3fb2ee34488f0ab5c87f
 )
 include(${CMAKE_BINARY_DIR}/_deps/CPM.cmake)


### PR DESCRIPTION
This pull request simply bumps the CPM.cmake to version [0.40.8](https://github.com/cpm-cmake/CPM.cmake/releases/tag/v0.40.8).