### PR TITLE
Bump Catch2 to Version 3.8.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -46,7 +46,7 @@ target_sources(
 
 if(PROJECT_IS_TOP_LEVEL AND ERRORS_ENABLE_TESTS)
   # Import Catch2 as the main testing framework
-  find_package(Catch2 3.7.1 REQUIRED)
+  find_package(Catch2 3.8.0 REQUIRED)
   include(Catch)
 
   # Append the main library properties instead of linking the library.


### PR DESCRIPTION
This pull request simply bumps Catch2 to version [3.8.0](https://github.com/catchorg/Catch2/releases/tag/v3.8.0).