### PR TITLE
Bump FMT to Version 11.2.0

### DIFF
--- a/components/format/CMakeLists.txt
+++ b/components/format/CMakeLists.txt
@@ -1,4 +1,4 @@
-find_package(FMT 11.1.0 REQUIRED)
+find_package(FMT 11.2.0 REQUIRED)
 
 add_library(errors_format INTERFACE)
 target_sources(


### PR DESCRIPTION
This pull request updates the FMT library to version [11.2.0](https://github.com/fmtlib/fmt/releases/tag/11.2.0).